### PR TITLE
Add knowledge unit data model and confidence scoring

### DIFF
--- a/server/craic_mcp/knowledge_unit.py
+++ b/server/craic_mcp/knowledge_unit.py
@@ -1,24 +1,27 @@
-# Pydantic model for CRAIC knowledge units.
+"""Pydantic models for CRAIC knowledge units."""
 
-from datetime import datetime, timezone
-from enum import Enum
+from datetime import UTC, datetime
+from enum import StrEnum
 
 from nanoid import generate
 from pydantic import BaseModel, Field, model_validator
-
 
 KU_ID_PREFIX = "ku_"
 KU_ID_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 KU_ID_LENGTH = 21
 
 
-class Tier(str, Enum):
+class Tier(StrEnum):
+    """Knowledge unit storage tier."""
+
     LOCAL = "local"
     TEAM = "team"
     GLOBAL = "global"
 
 
-class FlagReason(str, Enum):
+class FlagReason(StrEnum):
+    """Reason for flagging a knowledge unit."""
+
     STALE = "stale"
     INCORRECT = "incorrect"
     DUPLICATE = "duplicate"
@@ -28,16 +31,20 @@ class Flag(BaseModel):
     """A recorded flag against a knowledge unit."""
 
     reason: FlagReason
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
 
 class Insight(BaseModel):
+    """Tripartite insight: summary, detail, and recommended action."""
+
     summary: str
     detail: str
     action: str
 
 
 class Context(BaseModel):
+    """Language, framework, and pattern context for a knowledge unit."""
+
     languages: list[str] = Field(default_factory=list)
     frameworks: list[str] = Field(default_factory=list)
     pattern: str = ""
@@ -54,15 +61,24 @@ class Evidence(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def set_default_timestamps(cls, data: dict) -> dict:
-        """Ensure both timestamps are identical on creation."""
+        """Ensure timestamp consistency on creation."""
         if isinstance(data, dict):
-            now = datetime.now(timezone.utc)
-            data.setdefault("first_observed", now)
-            data.setdefault("last_confirmed", now)
+            first = data.get("first_observed")
+            last = data.get("last_confirmed")
+            if first is None and last is None:
+                now = datetime.now(UTC)
+                data["first_observed"] = now
+                data["last_confirmed"] = now
+            elif first is None:
+                data["first_observed"] = last
+            elif last is None:
+                data["last_confirmed"] = first
         return data
 
 
 class KnowledgeUnit(BaseModel):
+    """A single unit of shared agent knowledge."""
+
     id: str
     version: int = 1
     domain: list[str] = Field(min_length=1)

--- a/server/craic_mcp/scoring.py
+++ b/server/craic_mcp/scoring.py
@@ -1,9 +1,8 @@
-# Confidence scoring and relevance functions for knowledge units.
+"""Confidence scoring and relevance functions for knowledge units."""
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from .knowledge_unit import Flag, FlagReason, KnowledgeUnit
-
 
 CONFIRMATION_BOOST = 0.1
 FLAG_PENALTY = 0.15
@@ -13,9 +12,7 @@ CONFIDENCE_FLOOR = 0.0
 
 def apply_confirmation(unit: KnowledgeUnit) -> KnowledgeUnit:
     """Increment confirmations and boost confidence, capped at 1.0."""
-    new_confidence = min(
-        unit.evidence.confidence + CONFIRMATION_BOOST, CONFIDENCE_CEILING
-    )
+    new_confidence = min(unit.evidence.confidence + CONFIRMATION_BOOST, CONFIDENCE_CEILING)
     new_confirmations = unit.evidence.confirmations + 1
     return unit.model_copy(
         update={
@@ -23,7 +20,7 @@ def apply_confirmation(unit: KnowledgeUnit) -> KnowledgeUnit:
                 update={
                     "confidence": new_confidence,
                     "confirmations": new_confirmations,
-                    "last_confirmed": datetime.now(timezone.utc),
+                    "last_confirmed": datetime.now(UTC),
                 }
             )
         }
@@ -32,15 +29,11 @@ def apply_confirmation(unit: KnowledgeUnit) -> KnowledgeUnit:
 
 def apply_flag(unit: KnowledgeUnit, reason: FlagReason) -> KnowledgeUnit:
     """Reduce confidence and record the flag reason."""
-    new_confidence = max(
-        unit.evidence.confidence - FLAG_PENALTY, CONFIDENCE_FLOOR
-    )
+    new_confidence = max(unit.evidence.confidence - FLAG_PENALTY, CONFIDENCE_FLOOR)
     new_flag = Flag(reason=reason)
     return unit.model_copy(
         update={
-            "evidence": unit.evidence.model_copy(
-                update={"confidence": round(new_confidence, 2)}
-            ),
+            "evidence": unit.evidence.model_copy(update={"confidence": new_confidence}),
             "flags": [*unit.flags, new_flag],
         }
     )
@@ -65,9 +58,7 @@ def calculate_relevance(
     unit_domains = set(unit.domain)
     query_domain_set = set(query_domains)
     if unit_domains or query_domain_set:
-        domain_score = len(unit_domains & query_domain_set) / len(
-            unit_domains | query_domain_set
-        )
+        domain_score = len(unit_domains & query_domain_set) / len(unit_domains | query_domain_set)
     else:
         domain_score = 0.0
 
@@ -81,8 +72,4 @@ def calculate_relevance(
     if query_framework and query_framework in unit.context.frameworks:
         framework_score = 1.0
 
-    return (
-        domain_weight * domain_score
-        + language_weight * language_score
-        + framework_weight * framework_score
-    )
+    return domain_weight * domain_score + language_weight * language_score + framework_weight * framework_score

--- a/server/tests/test_knowledge_unit.py
+++ b/server/tests/test_knowledge_unit.py
@@ -1,9 +1,8 @@
 # Tests for knowledge unit data model and confidence scoring.
 
+from datetime import UTC
+
 import pytest
-
-from pydantic import ValidationError
-
 from craic_mcp.knowledge_unit import (
     Context,
     Evidence,
@@ -14,6 +13,7 @@ from craic_mcp.knowledge_unit import (
     create_knowledge_unit,
 )
 from craic_mcp.scoring import apply_confirmation, apply_flag, calculate_relevance
+from pydantic import ValidationError
 
 
 def _make_insight() -> Insight:
@@ -120,27 +120,15 @@ class TestCalculateRelevance:
         assert score == 0.0
 
     def test_language_match_adds_secondary_signal(self):
-        unit = _make_unit(
-            context=Context(languages=["python"], frameworks=[])
-        )
-        score_with_lang = calculate_relevance(
-            unit, ["databases"], query_language="python"
-        )
-        score_without_lang = calculate_relevance(
-            unit, ["databases"], query_language=None
-        )
+        unit = _make_unit(context=Context(languages=["python"], frameworks=[]))
+        score_with_lang = calculate_relevance(unit, ["databases"], query_language="python")
+        score_without_lang = calculate_relevance(unit, ["databases"], query_language=None)
         assert score_with_lang > score_without_lang
 
     def test_framework_match_adds_secondary_signal(self):
-        unit = _make_unit(
-            context=Context(languages=[], frameworks=["django"])
-        )
-        score_with_fw = calculate_relevance(
-            unit, ["databases"], query_framework="django"
-        )
-        score_without_fw = calculate_relevance(
-            unit, ["databases"], query_framework=None
-        )
+        unit = _make_unit(context=Context(languages=[], frameworks=["django"]))
+        score_with_fw = calculate_relevance(unit, ["databases"], query_framework="django")
+        score_without_fw = calculate_relevance(unit, ["databases"], query_framework=None)
         assert score_with_fw > score_without_fw
 
     def test_full_match_returns_one(self):
@@ -202,12 +190,26 @@ class TestEvidenceTimestamps:
         assert evidence.first_observed == evidence.last_confirmed
 
     def test_explicit_timestamps_are_preserved(self):
-        from datetime import datetime, timezone
+        from datetime import datetime
 
-        ts = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        ts = datetime(2025, 1, 1, tzinfo=UTC)
         evidence = Evidence(first_observed=ts, last_confirmed=ts)
         assert evidence.first_observed == ts
         assert evidence.last_confirmed == ts
+
+    def test_only_first_observed_copies_to_last_confirmed(self):
+        from datetime import datetime
+
+        ts = datetime(2025, 6, 15, tzinfo=UTC)
+        evidence = Evidence(first_observed=ts)
+        assert evidence.last_confirmed == ts
+
+    def test_only_last_confirmed_copies_to_first_observed(self):
+        from datetime import datetime
+
+        ts = datetime(2025, 6, 15, tzinfo=UTC)
+        evidence = Evidence(last_confirmed=ts)
+        assert evidence.first_observed == ts
 
 
 class TestConfidenceBounds:


### PR DESCRIPTION
## Summary

- `KnowledgeUnit` Pydantic model with tripartite insight, context, evidence fields
- Factory function with `ku_`-prefixed nanoid ID generation
- Confidence scoring: `apply_confirmation` (+0.1, cap 1.0), `apply_flag` (-0.15, floor 0.0)
- Relevance scoring: Jaccard similarity on domain tags (70%) + language/framework match (30%)
- 21 tests across 5 test classes, all passing

Closes #2

## Test plan

- [ ] `cd server && uv run pytest -v` — 21 tests pass
- [ ] `cd server && uv run ruff check .` — clean
- [ ] Schema matches design doc knowledge unit format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added knowledge unit creation and management with tiered access levels (Local, Team, Global), evidence tracking, and quality flagging.
  * Introduced confidence scoring system enabling relevance calculation based on domain overlap, language, and framework matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->