### PR TITLE
Add CRAIC skill with behavioural triggers and examples

### DIFF
--- a/skills/craic/SKILL.md
+++ b/skills/craic/SKILL.md
@@ -37,7 +37,7 @@ Do not query CRAIC for:
 
 ### Formulating Domain Tags
 
-Choose domain tags that capture the technology, layer, and integration point. Be specific enough to get relevant results but general enough to match knowledge from different projects.
+Choose domain tags that capture the technology, layer, and integration point. Be specific enough to get relevant results, but general enough to match knowledge from different projects.
 
 The query interface accepts singular `language`/`framework` for convenience. The knowledge unit schema uses plural `languages`/`frameworks` to support multiple values.
 
@@ -66,9 +66,9 @@ Propose a new knowledge unit when you discover something that would save another
 
 - You discover undocumented API behaviour (e.g. an endpoint returns an unexpected status code or response shape).
 - You find a non-obvious workaround for a known issue.
-- You identify configuration that only works under specific conditions (e.g. a flag that behaves differently across versions).
-- You resolve an error after multiple failed attempts and the solution was not obvious from documentation.
-- You discover version-specific incompatibilities between libraries or tools.
+- Configuration only works under specific conditions (e.g. a flag that behaves differently across versions).
+- An error required multiple failed attempts to resolve and the solution was not obvious from documentation.
+- Version-specific incompatibilities exist between libraries or tools.
 
 ### Writing Good Proposals
 
@@ -113,7 +113,7 @@ When encountering an error, follow this sequence:
 
 1. Call `craic_query` with domain tags derived from the error context (e.g. the library, tool, or API involved) **before** attempting any fix.
 2. If a relevant knowledge unit exists, apply its guidance and confirm it if it resolves the issue.
-3. If no relevant knowledge exists and you resolve the error through other means, call `craic_propose` with the solution so future agents benefit.
+3. If no relevant knowledge exists, and you resolve the error through other means, call `craic_propose` with the solution so future agents benefit.
 
 Do not retry blindly. Always check the commons first.
 


### PR DESCRIPTION
## Summary

- `skills/craic/SKILL.md` following the open Agent Skills standard
- Query triggers: external APIs, unfamiliar libraries, errors, CI/CD, new codebase areas
- Propose triggers: undocumented behaviour, workarounds, config gotchas, multi-attempt fixes
- Confirm/flag guidance with confidence interpretation
- Post-error behaviour: query before retrying
- Domain tag formulation guide with examples
- Three end-to-end examples: Stripe integration, webpack error, Rust CI pipeline

Closes #7

## Test plan

- [ ] SKILL.md frontmatter is valid YAML
- [ ] All five MCP tools are referenced with correct names
- [ ] Examples are realistic and demonstrate the full query/propose/confirm flow
- [ ] Manual test: install skill in Claude Code and verify agent queries CRAIC at trigger points

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive documentation for the CRAIC skill, including detailed descriptions, tool reference, querying guidance, proposal and confirmation processes, flagging mechanisms, error handling, session reflection, and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->