### PR TITLE
Fix MCP server cwd so plugin starts correctly

### DIFF
--- a/plugins/craic/.claude-plugin/plugin.json
+++ b/plugins/craic/.claude-plugin/plugin.json
@@ -8,7 +8,8 @@
   "mcpServers": {
     "craic": {
       "command": "uv",
-      "args": ["run", "--directory", "server", "craic-mcp-server"]
+      "args": ["run", "--directory", "server", "craic-mcp-server"],
+      "cwd": "${CLAUDE_PLUGIN_ROOT}"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add `cwd: ${CLAUDE_PLUGIN_ROOT}` to the MCP server config in `plugin.json`

The `mcpServers` config used `--directory server` (a relative path) without specifying `cwd`. Claude Code runs the command from the user's project directory, not the plugin installation directory, so `server/` was never found and the MCP process exited immediately with "No such file or directory".

Fixes the "Failed to reconnect to plugin:craic:craic" error.

## Test plan

- [x] Verified server fails without fix (`uv run --directory server` from project dir → "No such file or directory")
- [x] Verified server starts correctly with fix (from plugin cache dir → successful MCP handshake, all 6 tools registered)