### PR TITLE
Fix plugin failing to load due to duplicate hooks declaration

### DIFF
--- a/plugins/craic/.claude-plugin/plugin.json
+++ b/plugins/craic/.claude-plugin/plugin.json
@@ -1,15 +1,13 @@
 {
   "name": "craic",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Collective Reciprocal Agent Intelligence Commons — shared agent learning",
   "skills": "./skills/",
   "commands": "./commands/",
-  "hooks": "./hooks/hooks.json",
   "mcpServers": {
     "craic": {
       "command": "uv",
-      "args": ["run", "--directory", "server", "craic-mcp-server"],
-      "cwd": "${CLAUDE_PLUGIN_ROOT}"
+      "args": ["run", "--directory", "${CLAUDE_PLUGIN_ROOT}/server", "craic-mcp-server"]
     }
   }
 }


### PR DESCRIPTION
## Summary

- **Remove redundant `hooks` key from plugin manifest** — Claude Code auto-loads `hooks/hooks.json` from the plugin directory; declaring it in the manifest triggers duplicate detection that marks the entire plugin as `hook-load-failed`
- **Move `${CLAUDE_PLUGIN_ROOT}/server` into `args`** instead of relying on `cwd` for variable expansion, which is unreliable when the plugin is in a degraded state
- **Bump version to 0.1.1** to invalidate cached copies of the broken 0.1.0

The duplicate hooks error cascaded: SessionStart hooks never ran (venv never pre-built), and the MCP server launched without proper variable expansion, causing `No such file or directory (os error 2)` on every startup. Previous fix attempts (PR #33, commits fc455ff, 0c8bc3c) addressed symptoms downstream of this root cause.

Fixes #33

## Test plan

- [ ] Start a new Claude Code session in a project with the CRAIC plugin installed
- [ ] Verify no `hook-load-failed` errors in debug log
- [ ] Verify MCP server connects successfully (`/mcp` shows connected)
- [ ] Verify SessionStart hook runs (`uv sync` output in hook log)
- [ ] Verify CRAIC MCP tools are available (e.g. `craic-query`)