### PR TITLE
Make skill description action-oriented to improve auto-invocation

### DIFF
--- a/plugins/craic/skills/craic/SKILL.md
+++ b/plugins/craic/skills/craic/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: craic
-description: Query and contribute to the Collective Reciprocal Agent Intelligence Commons — shared knowledge that helps agents avoid known pitfalls and learn from each other's experiences.
+description: Use BEFORE starting any implementation task — query the shared knowledge commons for known pitfalls with the tools, libraries, APIs, or infrastructure you're about to use. Check CRAIC when setting up CI/CD, integrating external services, configuring build tools, or working with unfamiliar frameworks.
 ---
 
 # CRAIC Skill


### PR DESCRIPTION
## Summary

- Rewrites the CRAIC skill description from passive ("Query and contribute to...") to action-oriented ("Use BEFORE starting any implementation task...")
- Matches the pattern used by skills that reliably auto-invoke (brainstorming, TDD, debugging)
- Lists concrete trigger conditions: CI/CD, external services, build tools, unfamiliar frameworks

During demo testing, the agent consistently skipped invoking the CRAIC skill because the description explained what CRAIC *is* rather than *when to use it*.

## Test plan

- [ ] Start a fresh Claude session with CRAIC plugin installed
- [ ] Give a task that involves CI/CD setup
- [ ] Verify the agent considers invoking the CRAIC skill before acting