### PR TITLE
Change language/framework query from hard filter to soft ranking

### DIFF
--- a/plugins/craic/server/craic_mcp/local_store.py
+++ b/plugins/craic/server/craic_mcp/local_store.py
@@ -253,11 +253,6 @@ class LocalStore:
         # For larger stores, push coarse filters into SQL.
         units = [KnowledgeUnit.model_validate_json(row[0]) for row in rows]
 
-        if language:
-            units = [u for u in units if language in u.context.languages]
-        if framework:
-            units = [u for u in units if framework in u.context.frameworks]
-
         scored = []
         for unit in units:
             relevance = calculate_relevance(

--- a/plugins/craic/server/tests/test_local_store.py
+++ b/plugins/craic/server/tests/test_local_store.py
@@ -257,7 +257,7 @@ class TestQuery:
         results = store.query(["databases"], limit=3)
         assert len(results) == 3
 
-    def test_filters_by_language(self, store: LocalStore):
+    def test_language_boosts_ranking_without_excluding(self, store: LocalStore):
         python_unit = _make_unit(
             domain=["databases"],
             context=Context(languages=["python"]),
@@ -270,10 +270,10 @@ class TestQuery:
         store.insert(go_unit)
 
         results = store.query(["databases"], language="python")
-        assert len(results) == 1
+        assert len(results) == 2
         assert results[0].id == python_unit.id
 
-    def test_filters_by_framework(self, store: LocalStore):
+    def test_framework_boosts_ranking_without_excluding(self, store: LocalStore):
         django_unit = _make_unit(
             domain=["web"],
             context=Context(frameworks=["django"]),
@@ -286,10 +286,10 @@ class TestQuery:
         store.insert(flask_unit)
 
         results = store.query(["web"], framework="django")
-        assert len(results) == 1
+        assert len(results) == 2
         assert results[0].id == django_unit.id
 
-    def test_combined_language_and_framework_filter(self, store: LocalStore):
+    def test_combined_language_and_framework_boosts_ranking(self, store: LocalStore):
         match = _make_unit(
             domain=["web"],
             context=Context(languages=["python"], frameworks=["django"]),
@@ -302,7 +302,7 @@ class TestQuery:
         store.insert(partial)
 
         results = store.query(["web"], language="python", framework="django")
-        assert len(results) == 1
+        assert len(results) == 2
         assert results[0].id == match.id
 
     def test_higher_confidence_ranks_higher(self, store: LocalStore):

--- a/plugins/craic/server/tests/test_server.py
+++ b/plugins/craic/server/tests/test_server.py
@@ -86,18 +86,18 @@ class TestCraicQuery:
         assert len(result["results"]) == 1
         assert "databases" in result["results"][0]["domain"]
 
-    def test_query_filters_by_language(self) -> None:
+    def test_query_boosts_matching_language(self) -> None:
         _propose_unit(domain=["web"], language="python")
         _propose_unit(domain=["web"], language="go")
         result = craic_query(domain=["web"], language="python")
-        assert len(result["results"]) == 1
+        assert len(result["results"]) == 2
         assert "python" in result["results"][0]["context"]["languages"]
 
-    def test_query_filters_by_framework(self) -> None:
+    def test_query_boosts_matching_framework(self) -> None:
         _propose_unit(domain=["web"], framework="fastapi")
         _propose_unit(domain=["web"], framework="django")
         result = craic_query(domain=["web"], framework="fastapi")
-        assert len(result["results"]) == 1
+        assert len(result["results"]) == 2
         assert "fastapi" in result["results"][0]["context"]["frameworks"]
 
     def test_query_respects_limit(self) -> None:


### PR DESCRIPTION
## Summary

- Removes hard language/framework filter from `LocalStore.query()` that was silently excluding knowledge units without matching tags
- Language and framework now only influence ranking (via `calculate_relevance` scoring), not inclusion
- Discovered during demo testing: `craic_query(domain=["github-actions"], language="python")` was dropping the `actions/checkout` KU because it had no language tags, even though its domain tags matched

## Test plan

- [x] All 178 tests pass (updated 3 filter tests to assert ranking behaviour instead of exclusion)
- [x] Lint passes
- [ ] Manual: query with `language="python"` returns units without python tag, ranked lower