### PR TITLE
Add FTS5 full-text search for knowledge queries

### DIFF
--- a/plugins/craic/server/craic_mcp/local_store.py
+++ b/plugins/craic/server/craic_mcp/local_store.py
@@ -55,6 +55,11 @@ CREATE INDEX IF NOT EXISTS idx_domains_domain
     ON knowledge_unit_domains(domain);
 """
 
+_FTS_SCHEMA_SQL = """
+CREATE VIRTUAL TABLE IF NOT EXISTS knowledge_units_fts
+    USING fts5(id UNINDEXED, summary, detail, action);
+"""
+
 
 def _normalise_domains(domains: list[str]) -> list[str]:
     """Lowercase, strip whitespace, drop empties, and deduplicate domain tags."""
@@ -92,8 +97,9 @@ class LocalStore:
         return conn
 
     def _ensure_schema(self) -> None:
-        """Create tables and indexes if they do not exist."""
+        """Create tables, indexes, and FTS virtual table if they do not exist."""
         self._conn.executescript(_SCHEMA_SQL)
+        self._conn.executescript(_FTS_SCHEMA_SQL)
 
     def _check_open(self) -> None:
         """Raise if the store has been closed."""
@@ -150,6 +156,10 @@ class LocalStore:
                 "INSERT INTO knowledge_unit_domains (unit_id, domain) VALUES (?, ?)",
                 [(unit.id, d) for d in domains],
             )
+            self._conn.execute(
+                "INSERT INTO knowledge_units_fts (id, summary, detail, action) VALUES (?, ?, ?, ?)",
+                (unit.id, unit.insight.summary, unit.insight.detail, unit.insight.action),
+            )
 
     def get(self, unit_id: str) -> KnowledgeUnit | None:
         """Retrieve a knowledge unit by ID.
@@ -200,6 +210,14 @@ class LocalStore:
                 "INSERT INTO knowledge_unit_domains (unit_id, domain) VALUES (?, ?)",
                 [(unit.id, d) for d in domains],
             )
+            self._conn.execute(
+                "DELETE FROM knowledge_units_fts WHERE id = ?",
+                (unit.id,),
+            )
+            self._conn.execute(
+                "INSERT INTO knowledge_units_fts (id, summary, detail, action) VALUES (?, ?, ?, ?)",
+                (unit.id, unit.insight.summary, unit.insight.detail, unit.insight.action),
+            )
 
     def query(
         self,
@@ -249,7 +267,27 @@ class LocalStore:
         """
         rows = self._conn.execute(sql, normalised).fetchall()
 
-        units = [KnowledgeUnit.model_validate_json(row[0]) for row in rows]
+        # Also search FTS5 for units matching query terms in their text.
+        fts_terms = " OR ".join(f'"{term}"' for term in normalised)
+        fts_sql = """
+            SELECT ku.data
+            FROM knowledge_units_fts fts
+            JOIN knowledge_units ku ON ku.id = fts.id
+            WHERE knowledge_units_fts MATCH ?
+        """
+        try:
+            fts_rows = self._conn.execute(fts_sql, (fts_terms,)).fetchall()
+        except sqlite3.OperationalError:
+            fts_rows = []
+
+        # Merge and deduplicate by ID.
+        seen: set[str] = set()
+        units: list[KnowledgeUnit] = []
+        for row in [*rows, *fts_rows]:
+            unit = KnowledgeUnit.model_validate_json(row[0])
+            if unit.id not in seen:
+                seen.add(unit.id)
+                units.append(unit)
 
         scored = []
         for unit in units:

--- a/plugins/craic/server/tests/test_local_store.py
+++ b/plugins/craic/server/tests/test_local_store.py
@@ -320,6 +320,79 @@ class TestQuery:
         assert results[0].id == high_conf.id
 
 
+class TestFTS:
+    def test_fts_finds_units_by_summary_text(self, store: LocalStore):
+        unit = _make_unit(
+            domain=["ci"],
+            insight=Insight(
+                summary="actions/checkout latest version is v6",
+                detail="LLMs default to v4.",
+                action="Pin to v6.",
+            ),
+        )
+        store.insert(unit)
+
+        results = store.query(["checkout"])
+        assert len(results) == 1
+        assert results[0].id == unit.id
+
+    def test_fts_finds_units_by_detail_text(self, store: LocalStore):
+        unit = _make_unit(
+            domain=["ci"],
+            insight=Insight(
+                summary="Stale action versions",
+                detail="The astral-sh/setup-uv action is now at v7.",
+                action="Update to v7.",
+            ),
+        )
+        store.insert(unit)
+
+        results = store.query(["setup-uv"])
+        assert len(results) == 1
+        assert results[0].id == unit.id
+
+    def test_fts_deduplicates_with_domain_matches(self, store: LocalStore):
+        unit = _make_unit(
+            domain=["github-actions"],
+            insight=Insight(
+                summary="github-actions checkout is at v6",
+                detail="Detail.",
+                action="Action.",
+            ),
+        )
+        store.insert(unit)
+
+        results = store.query(["github-actions"])
+        assert len(results) == 1
+
+    def test_fts_updated_after_unit_update(self, store: LocalStore):
+        unit = _make_unit(
+            domain=["ci"],
+            insight=Insight(
+                summary="Old summary about webpack",
+                detail="Old detail.",
+                action="Old action.",
+            ),
+        )
+        store.insert(unit)
+
+        updated = unit.model_copy(
+            update={
+                "insight": Insight(
+                    summary="New summary about vite bundler",
+                    detail="New detail.",
+                    action="New action.",
+                )
+            }
+        )
+        store.update(updated)
+
+        assert store.query(["webpack"]) == []
+        results = store.query(["vite"])
+        assert len(results) == 1
+        assert results[0].id == unit.id
+
+
 class TestDomainNormalisation:
     def test_stores_domains_as_lowercase(self, store: LocalStore):
         unit = _make_unit(domain=["API", "Payments"])


### PR DESCRIPTION
## Summary
- Add SQLite FTS5 virtual table indexing knowledge unit summary, detail, and action text fields.
- Query now searches both domain tags and free text, merging and deduplicating results before relevance scoring.
- Improves recall when query domain tags don't exactly match stored tags but the text content is relevant (e.g. querying `["checkout"]` finds a unit with "actions/checkout" in its summary).

**Note:** First commit duplicates the hard-filter removal from #37 since this branch is based on `origin/main`. Rebase after #37 merges to drop it.

## Test plan
- [x] 4 new FTS tests: summary match, detail match, deduplication, update propagation
- [x] All 182 tests pass (`make test`)
- [x] Lint passes (`make lint`)