### PR TITLE
Bump plugin version to 0.1.2

### DIFF
--- a/plugins/craic/.claude-plugin/plugin.json
+++ b/plugins/craic/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "craic",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Collective Reciprocal Agent Intelligence Commons — shared agent learning",
   "skills": "./skills/",
   "commands": "./commands/",


### PR DESCRIPTION
## Summary
- Bump plugin version from 0.1.1 to 0.1.2 covering #36, #37, #38.

## Test plan
- [x] Version string updated in plugin.json