### PR TITLE
Add OpenCode install/uninstall support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,62 @@
-.PHONY: lint format format-check test typecheck
+.DEFAULT_GOAL := help
 
+.PHONY: help
+help:
+	@echo "craic - Collective Reciprocal Agent Intelligence Commons"
+	@echo ""
+	@echo "Claude Code (recommended):"
+	@echo "  claude plugin marketplace add mozilla-ai/craic"
+	@echo "  claude plugin install craic"
+	@echo ""
+	@echo "OpenCode:"
+	@echo "  make install-opencode                        Install globally (~/.config/opencode/)"
+	@echo "  make install-opencode PROJECT=/path/to/app   Install into a specific project"
+	@echo "  make uninstall-opencode                      Remove OpenCode install"
+	@echo ""
+	@echo "Development:"
+	@echo "  make test       Run all tests"
+	@echo "  make lint       Run linters"
+	@echo "  make format     Format code"
+
+.PHONY: install-opencode
+install-opencode:
+ifdef PROJECT
+	@bash "$(CURDIR)/scripts/install-opencode.sh" install --project "$(PROJECT)"
+else
+	@bash "$(CURDIR)/scripts/install-opencode.sh" install
+endif
+
+.PHONY: uninstall-opencode
+uninstall-opencode:
+ifdef PROJECT
+	@bash "$(CURDIR)/scripts/install-opencode.sh" uninstall --project "$(PROJECT)"
+else
+	@bash "$(CURDIR)/scripts/install-opencode.sh" uninstall
+endif
+
+.PHONY: lint
 lint:
 	cd plugins/craic/server && uv run ruff check .
 	cd plugins/craic/server && uv run ruff format --check .
 	cd team-api && uv run ruff check .
 	cd team-api && uv run ruff format --check .
 
+.PHONY: format
 format:
 	cd plugins/craic/server && uv run ruff format .
 	cd team-api && uv run ruff format .
 
+.PHONY: format-check
 format-check:
 	cd plugins/craic/server && uv run ruff format --check .
 	cd team-api && uv run ruff format --check .
 
+.PHONY: typecheck
 typecheck:
 	cd plugins/craic/server && uv sync --group dev && uvx ty check craic_mcp --python .venv
 	cd team-api && uv sync --group dev && uvx ty check team_api --python .venv
 
+.PHONY: test
 test:
 	cd plugins/craic/server && uv sync --group dev && uvx ty check craic_mcp --python .venv
 	cd team-api && uv sync --group dev && uvx ty check team_api --python .venv

--- a/README.md
+++ b/README.md
@@ -8,6 +8,33 @@ That's what this project does for AI agents: shared, experience-driven knowledge
 
 An open standard for shared agent learning. Agents persist, share, and query collective knowledge so they stop rediscovering the same failures independently.
 
+## Installation
+
+Requires: `uv`
+
+### Claude Code (plugin)
+
+```
+claude plugin marketplace add mozilla-ai/craic
+claude plugin install craic
+```
+
+### OpenCode (MCP server)
+
+Also requires: `jq`
+
+```bash
+git clone https://github.com/mozilla-ai/craic.git
+cd craic
+make install-opencode
+```
+
+Or for a specific project:
+
+```bash
+make install-opencode PROJECT=/path/to/your/project
+```
+
 ## Architecture
 
 CRAIC runs across three runtime boundaries: the agent process (plugin configuration), a local MCP server (knowledge logic and private store), and a Docker container (team-shared API).

--- a/scripts/install-opencode.sh
+++ b/scripts/install-opencode.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Install or uninstall CRAIC for OpenCode.
+#
+# Usage:
+#   install-opencode.sh install [--project <path>]
+#   install-opencode.sh uninstall [--project <path>]
+#
+# Without --project, installs globally to ~/.config/opencode/.
+# With --project, installs into <path>/.opencode/.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PLUGIN_DIR="${REPO_ROOT}/plugins/craic"
+SERVER_DIR="${PLUGIN_DIR}/server"
+
+# -- Dependencies. --
+
+if ! command -v jq &>/dev/null; then
+    echo "Error: jq is required. Install with: brew install jq" >&2
+    exit 1
+fi
+
+# -- Argument parsing. --
+
+usage() {
+    echo "Usage: $(basename "$0") <install|uninstall> [--project <path>]"
+    exit 1
+}
+
+if [[ $# -lt 1 ]]; then
+    usage
+fi
+
+ACTION="$1"
+shift
+PROJECT=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --project)
+            PROJECT="${2:?--project requires a path}"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            ;;
+    esac
+done
+
+if [[ -n "${PROJECT}" ]]; then
+    TARGET="${PROJECT}/.opencode"
+else
+    TARGET="${HOME}/.config/opencode"
+fi
+
+# -- Core: apply an action to a set of sources. --
+# Usage: apply <install|uninstall> <target_dir> <label> <strip_ext> <sources...>
+# Sources are pre-expanded by the caller (glob expansion happens at call site).
+
+apply() {
+    local action="$1" target_dir="$2" label="$3" strip_ext="$4"
+    shift 4
+
+    [[ "${action}" == "install" ]] && mkdir -p "${target_dir}"
+
+    for src in "$@"; do
+        [[ -e "${src}" ]] || continue
+        local name
+        name="$(basename "${src}" "${strip_ext}")"
+
+        if [[ "${action}" == "install" ]]; then
+            if [[ -d "${src}" ]]; then
+                ln -sfn "${src}" "${target_dir}/$(basename "${src}")"
+            else
+                ln -sf "${src}" "${target_dir}/"
+            fi
+            echo "  Linked ${label}: ${name}"
+        else
+            rm -rf "${target_dir}/$(basename "${src}")"
+            echo "  Removed ${label}: ${name}"
+        fi
+    done
+}
+
+# -- Generate OpenCode command files from Claude Code command files. --
+# Strips the `name:` frontmatter field and adds `agent: build`.
+
+generate_commands() {
+    local target_dir="$1"
+    mkdir -p "${target_dir}"
+
+    for cmd_file in "${PLUGIN_DIR}"/commands/*.md; do
+        [[ -f "${cmd_file}" ]] || continue
+
+        local basename
+        basename="$(basename "${cmd_file}")"
+
+        awk '
+            BEGIN { in_fm=0; past_fm=0 }
+            /^---$/ {
+                if (!in_fm) { in_fm=1; print; next }
+                else { print "agent: build"; print "---"; past_fm=1; next }
+            }
+            in_fm && /^name:/ { next }
+            { print }
+        ' "${cmd_file}" > "${target_dir}/${basename}"
+        echo "  Generated command: /${basename%.md}"
+    done
+}
+
+remove_commands() {
+    local target_dir="$1"
+
+    for cmd_file in "${PLUGIN_DIR}"/commands/*.md; do
+        [[ -f "${cmd_file}" ]] || continue
+        local basename
+        basename="$(basename "${cmd_file}")"
+        if [[ -f "${target_dir}/${basename}" ]]; then
+            rm -f "${target_dir}/${basename}"
+            echo "  Removed command: /${basename%.md}"
+        fi
+    done
+}
+
+# -- MCP configuration. --
+
+configure_mcp() {
+    local config_file="${TARGET}/opencode.json"
+    local server_path
+    server_path="$(cd "${SERVER_DIR}" && pwd)"
+
+    local craic_entry
+    craic_entry=$(jq -n \
+        --arg dir "${server_path}" \
+        '{ type: "local", command: ["uv", "run", "--directory", $dir, "craic-mcp-server"] }')
+
+    if [[ -f "${config_file}" ]]; then
+        if jq -e '.mcp.craic' "${config_file}" &>/dev/null; then
+            echo "  MCP server already configured in ${config_file}"
+        else
+            local tmp
+            tmp=$(jq --argjson entry "${craic_entry}" '.mcp.craic = $entry' "${config_file}")
+            printf '%s\n' "${tmp}" > "${config_file}"
+            echo "  Added CRAIC MCP server to ${config_file}"
+        fi
+    else
+        mkdir -p "$(dirname "${config_file}")"
+        jq -n --argjson entry "${craic_entry}" \
+            '{ "$schema": "https://opencode.ai/config.json", mcp: { craic: $entry } }' \
+            > "${config_file}"
+        echo "  Created ${config_file} with CRAIC MCP server"
+    fi
+}
+
+remove_mcp() {
+    local config_file="${TARGET}/opencode.json"
+    [[ -f "${config_file}" ]] || return 0
+
+    local tmp
+    tmp=$(jq 'del(.mcp.craic) | if .mcp == {} then del(.mcp) else . end' "${config_file}")
+    printf '%s\n' "${tmp}" > "${config_file}"
+    echo "  Removed CRAIC MCP server from ${config_file}"
+}
+
+# -- Dispatch. --
+
+case "${ACTION}" in
+    install)
+        echo "Installing CRAIC for OpenCode (${TARGET})..."
+        apply install "${TARGET}/skills" "skill" "" "${PLUGIN_DIR}"/skills/*/
+        generate_commands "${TARGET}/commands"
+        configure_mcp
+        echo ""
+        echo "Done. Restart OpenCode to pick up the changes."
+        ;;
+    uninstall)
+        echo "Removing CRAIC for OpenCode (${TARGET})..."
+        apply uninstall "${TARGET}/skills" "skill" "" "${PLUGIN_DIR}"/skills/*/
+        remove_commands "${TARGET}/commands"
+        remove_mcp
+        echo ""
+        echo "Done."
+        ;;
+    *)
+        usage
+        ;;
+esac


### PR DESCRIPTION
## Summary

- Add `make install-opencode` / `make uninstall-opencode` Makefile targets
- Add `scripts/install-opencode.sh` — symlinks skills, generates command files (strips Claude Code `name:` frontmatter, adds `agent: build`), configures MCP server in `opencode.json` using `jq`
- Supports global (`~/.config/opencode/`) and project-level (`--project`) installs with idempotent re-install
- Add Installation section to README covering both Claude Code and OpenCode

## Test plan

- [ ] `make uninstall-opencode` from clean state (no-op)
- [ ] `make install-opencode` — verify symlink, commands, MCP config
- [ ] `make install-opencode` again — verify idempotent ("already configured")
- [ ] `make uninstall-opencode` — verify cleanup
- [ ] `make install-opencode PROJECT=/tmp/test` — verify project-level install
- [ ] `make uninstall-opencode PROJECT=/tmp/test` — verify project-level cleanup