### PR TITLE
Add AGENTS.md rule to OpenCode install script

### DIFF
--- a/scripts/install-opencode.sh
+++ b/scripts/install-opencode.sh
@@ -165,17 +165,23 @@ remove_agents_md() {
         return 0
     fi
 
+    if ! grep -qF "${CRAIC_MARKER_END}" "${agents_file}"; then
+        echo "  Warning: ${agents_file} has start marker but no end marker — skipping" >&2
+        return 0
+    fi
+
     # Remove the CRAIC section and any trailing blank lines it left behind.
     local tmp
     tmp=$(awk -v start="${CRAIC_MARKER_START}" -v end="${CRAIC_MARKER_END}" '
         $0 == start { skip=1; next }
         $0 == end   { skip=0; next }
         skip { next }
-        { buf = buf $0 "\n" }
+        { n++; lines[n] = $0 }
         END {
-            # Strip trailing blank lines.
-            sub(/\n[[:space:]\n]*$/, "\n", buf)
-            printf "%s", buf
+            # Find last non-blank line.
+            last = n
+            while (last > 0 && lines[last] ~ /^[[:space:]]*$/) last--
+            for (i = 1; i <= last; i++) print lines[i]
         }
     ' "${agents_file}")
 


### PR DESCRIPTION
## Summary

- Add `configure_agents_md` / `remove_agents_md` functions to the OpenCode install script
- On install, creates or appends a CRAIC section to `AGENTS.md` using HTML comment markers for clean add/remove
- On uninstall, removes only the CRAIC section, preserving all other content
- If CRAIC was the only content, deletes the file entirely

OpenCode skills are on-demand — the model must explicitly call `skill()` to load them. Without a rule in `AGENTS.md`, the model has the MCP tools available but no instructions telling it to load the skill. Testing confirmed that GPT-5.2 via OpenCode skipped the skill entirely without this rule, but loaded and followed it with the rule present.

## Test plan

- [ ] `make install-opencode` creates `AGENTS.md` with CRAIC section
- [ ] Running install again is idempotent (doesn't duplicate)
- [ ] Existing `AGENTS.md` content is preserved when appending
- [ ] `make uninstall-opencode` removes only the CRAIC section
- [ ] Uninstall with CRAIC as sole content deletes the file