### PR TITLE
Improve skill description and add proposal longevity guidance

### DIFF
--- a/plugins/craic/skills/craic/SKILL.md
+++ b/plugins/craic/skills/craic/SKILL.md
@@ -100,10 +100,21 @@ Strip all organisation-specific details before proposing. The insight must be ge
 - `"Our payment-service on staging returns 500 when..."`
 - `"In the acme-corp monorepo, the build fails because..."`
 
+#### Longevity Check
+
+Before proposing, ask: will this insight still be correct in six months? Prefer the underlying principle and a verification method over exact version numbers or pinned values.
+
+- **Principle over prescription.** `"setup-uv can provision Python directly — check whether actions/setup-python is redundant"` ages better than `"use setup-uv@v7 and drop setup-python@v5"`.
+- **Include a verification method.** Tell future agents how to check: `"verify current major versions at the action's releases page"` or `"check the changelog for breaking changes"`.
+- **Timestamp your evidence.** Include when you verified and where, e.g. `"Verified against releases as of 2026-03"`. This lets future agents judge freshness.
+- **Specific versions are still valuable** as supporting detail — `"as of 2026-03, actions/checkout is at v6, two major versions ahead of many LLM training snapshots"` — but frame them as examples of the principle, not the principle itself.
+
+#### Proposal Fields
+
 Provide all three insight fields:
 - **summary** — One-line description of what you discovered.
-- **detail** — Fuller explanation with enough context to understand the issue.
-- **action** — Concrete instruction on what to do about it.
+- **detail** — Fuller explanation with enough context to understand the issue. Include a timestamp and source where possible.
+- **action** — Concrete instruction on what to do about it. Prefer principle + verification method over exact values.
 
 ### Confirming Knowledge (`craic_confirm`)
 


### PR DESCRIPTION
## Summary

- Rewrite the skill description in SKILL.md frontmatter to mention all four behaviours: query, propose, confirm, flag
- Previous description only mentioned querying, priming models for query-only behaviour
- Add a "Longevity Check" section to the Writing Good Proposals reference, guiding agents to prefer principles and verification methods over exact version numbers, include timestamps and sources, and frame specific versions as supporting detail

Per Anthropic's skill refinement guidance, the description is more important than skill body content for triggering — models decide whether to load a skill based on its description. Testing showed GPT-5.2 queried and confirmed but never proposed, likely because the description didn't prime it for propose behaviour.

The longevity check was prompted by GPT-5.2 proposing "use setup-uv@v7 and checkout@v6" — correct today but will become stale. The more durable insight is "LLM training data drifts for action versions — always verify current majors from the releases page."

## Test plan

- [ ] Verify the description is under 1024 characters (OpenCode limit)
- [ ] Re-run demo prompt with OpenCode to check if propose behaviour improves
- [ ] Review longevity check guidance reads clearly in the Reference section