### PR TITLE
Skip local storage when team API accepts proposal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ ENV/
 dist/
 build/
 
+node_modules/
+
 .ruff_cache/
 
 .pytest_cache/

--- a/plugins/craic/server/craic_mcp/server.py
+++ b/plugins/craic/server/craic_mcp/server.py
@@ -25,7 +25,7 @@ from .knowledge_unit import (
 )
 from .local_store import LocalStore
 from .scoring import apply_confirmation, apply_flag, calculate_relevance
-from .team_client import TeamClient
+from .team_client import TeamClient, TeamRejectedError
 
 logger = logging.getLogger(__name__)
 
@@ -278,8 +278,10 @@ def craic_propose(
 ) -> dict:
     """Propose a new knowledge unit.
 
-    Always stores in the local store. Also pushes to the team API on a
-    best-effort basis for sharing across the team.
+    When a team API is configured, proposals are sent there for human
+    review and nothing is stored locally. If the team API is unreachable,
+    the unit is stored locally as a fallback. When no team API is
+    configured, the unit is always stored locally.
 
     Args:
         summary: Concise description of the insight.
@@ -306,7 +308,6 @@ def craic_propose(
     cleaned_framework = framework.strip() if framework else None
     cleaned_pattern = pattern.strip() if pattern else ""
 
-    store = _get_store()
     context = Context(
         languages=[cleaned_language] if cleaned_language else [],
         frameworks=[cleaned_framework] if cleaned_framework else [],
@@ -322,24 +323,28 @@ def craic_propose(
         context=context,
         tier=Tier.LOCAL,
     )
-    store.insert(unit)
 
-    result: dict = {
+    team_client = _get_team_client()
+    if team_client is not None:
+        try:
+            team_unit = team_client.propose(unit)
+        except TeamRejectedError as exc:
+            return {"error": f"Team API rejected proposal: {exc.detail}"}
+        if team_unit is not None:
+            return {
+                "id": team_unit.id,
+                "tier": team_unit.tier.value,
+                "message": f"Knowledge unit proposed to team as {team_unit.id}.",
+            }
+        logger.warning("Team API unreachable; falling back to local storage.")
+
+    store = _get_store()
+    store.insert(unit)
+    return {
         "id": unit.id,
         "tier": unit.tier.value,
         "message": f"Knowledge unit {unit.id} stored locally.",
     }
-
-    team_client = _get_team_client()
-    if team_client is not None:
-        team_unit = team_client.propose(unit)
-        if team_unit is not None:
-            result["team_id"] = team_unit.id
-            result["message"] += f" Also shared to team as {team_unit.id}."
-        else:
-            logger.info("Team API unavailable for propose; stored locally only.")
-
-    return result
 
 
 @mcp.tool()

--- a/plugins/craic/server/craic_mcp/team_client.py
+++ b/plugins/craic/server/craic_mcp/team_client.py
@@ -22,6 +22,16 @@ _DEFAULT_TIMEOUT = 5.0
 _GRACEFUL_ERRORS = (httpx.HTTPError, ValueError, ValidationError)
 
 
+class TeamRejectedError(Exception):
+    """Raised when the team API explicitly rejects a request (HTTP 4xx/5xx)."""
+
+    def __init__(self, status_code: int, detail: str) -> None:
+        """Initialise with the HTTP status code and response body."""
+        self.status_code = status_code
+        self.detail = detail
+        super().__init__(f"Team API rejected request ({status_code}): {detail}")
+
+
 class TeamClient:
     """Synchronous HTTP client for the CRAIC Team API.
 
@@ -109,7 +119,11 @@ class TeamClient:
 
         Returns:
             The team-stored unit (with team tier and ID), or None if
-            the team API is unreachable.
+            the team API is unreachable due to a transport error.
+
+        Raises:
+            TeamRejectedError: If the team API explicitly rejects the
+                proposal with an HTTP 4xx/5xx status.
         """
         body = {
             "domain": unit.domain,
@@ -121,8 +135,13 @@ class TeamClient:
             resp = self._client.post("/propose", json=body)
             resp.raise_for_status()
             return KnowledgeUnit.model_validate(resp.json())
+        except httpx.HTTPStatusError as exc:
+            raise TeamRejectedError(
+                status_code=exc.response.status_code,
+                detail=exc.response.text,
+            ) from exc
         except _GRACEFUL_ERRORS:
-            logger.debug("Team API propose failed", exc_info=True)
+            logger.debug("Team API propose unreachable", exc_info=True)
             return None
 
     def confirm(self, unit_id: str) -> KnowledgeUnit | None:

--- a/plugins/craic/server/tests/test_server.py
+++ b/plugins/craic/server/tests/test_server.py
@@ -302,11 +302,41 @@ class TestCraicProposeWithTeam:
         monkeypatch.setattr(server, "_get_team_client", lambda: mock_client)
 
         result = _propose_unit(domain=["api"])
-        assert result["team_id"] == "ku_team_pushed"
-        assert "shared to team" in result["message"]
+        assert result["id"] == "ku_team_pushed"
+        assert result["tier"] == "team"
+        assert "proposed to team" in result["message"]
         mock_client.propose.assert_called_once()
 
-    def test_propose_succeeds_when_team_unreachable(
+    def test_propose_skips_local_store_when_team_succeeds(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        team_unit = _make_team_unit(unit_id="ku_team_only")
+        mock_client = MagicMock()
+        mock_client.propose.return_value = team_unit
+        monkeypatch.setattr(server, "_get_team_client", lambda: mock_client)
+
+        _propose_unit(domain=["api"])
+        local_results = craic_query(domain=["api"])
+        assert len(local_results["results"]) == 0
+
+    def test_propose_returns_error_when_team_rejects(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from craic_mcp.team_client import TeamRejectedError
+
+        mock_client = MagicMock()
+        mock_client.propose.side_effect = TeamRejectedError(422, "Invalid domain")
+        monkeypatch.setattr(server, "_get_team_client", lambda: mock_client)
+
+        result = _propose_unit(domain=["api"])
+        assert "error" in result
+        assert "rejected" in result["error"].lower()
+        local_results = craic_query(domain=["api"])
+        assert len(local_results["results"]) == 0
+
+    def test_propose_falls_back_to_local_when_team_unreachable(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -316,7 +346,10 @@ class TestCraicProposeWithTeam:
 
         result = _propose_unit(domain=["api"])
         assert result["id"].startswith("ku_")
-        assert "team_id" not in result
+        assert result["tier"] == "local"
+        assert "stored locally" in result["message"]
+        local_results = craic_query(domain=["api"])
+        assert len(local_results["results"]) == 1
 
 
 class TestCraicConfirm:

--- a/plugins/craic/server/tests/test_team_client.py
+++ b/plugins/craic/server/tests/test_team_client.py
@@ -127,6 +127,20 @@ class TestTeamClientPropose:
         monkeypatch.setattr(client._client, "post", _raise_connect_error)
         assert client.propose(_sample_unit()) is None
 
+    def test_propose_raises_on_http_rejection(
+        self,
+        client: TeamClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from craic_mcp.team_client import TeamRejectedError
+
+        response = _mock_response(422, {"detail": "Invalid domain"})
+        monkeypatch.setattr(client._client, "post", lambda *_a, **_kw: response)
+
+        with pytest.raises(TeamRejectedError) as exc_info:
+            client.propose(_sample_unit())
+        assert exc_info.value.status_code == 422
+
     def test_propose_parses_response(
         self,
         client: TeamClient,


### PR DESCRIPTION
## Summary

- When `CRAIC_TEAM_ADDR` is configured and reachable, `craic_propose` now sends to the team API only — no local copy is stored
- Falls back to local storage when the team API is unreachable
- When no team API is configured, behavior is unchanged (local-only)
- Adds `node_modules/` to `.gitignore`

**Why:** Previously proposals were always stored locally *and* sent to team, meaning a rejected KU would linger in the agent's local store with no way to know it was rejected.

## Test plan

- [ ] `test_propose_skips_local_store_when_team_succeeds` — verifies no local insert when team accepts
- [ ] `test_propose_falls_back_to_local_when_team_unreachable` — verifies local fallback with query confirmation
- [ ] `test_propose_pushes_to_team` — verifies team ID returned and message updated
- [ ] Full suite: 225 tests passing (150 plugin + 75 team-api)

Related: #59 (tracks the reverse direction — promoting local KUs to team)