### PR TITLE
Bump plugin version to 0.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "craic",
       "source": "./plugins/craic",
       "description": "Collective Reciprocal Agent Intelligence Commons — shared agent learning",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "category": "knowledge",
       "tags": ["knowledge-sharing", "agent-learning", "agent-commons","mcp", "pitfall-avoidance", "team-knowledge", "api-quirks"]
     }

--- a/plugins/craic/.claude-plugin/plugin.json
+++ b/plugins/craic/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "craic",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "Collective Reciprocal Agent Intelligence Commons — shared agent learning",
   "skills": "./skills/",
   "commands": "./commands/",


### PR DESCRIPTION
## Summary

- Bump `plugins/craic/.claude-plugin/plugin.json` from 0.1.5 to 0.2.0.
- Bump `.claude-plugin/marketplace.json` from 0.1.0 to 0.2.0.

Minor version bump reflecting new capabilities since 0.1.5:
- Team review UI with auth, review queue, and dashboard (#57)
- Propose flow fix — skip local storage when team accepts (#60)
- Startup drain to promote local fallback KUs to team (#61)
- Async TeamClient conversion

## Test plan

- [ ] Verify plugin loads correctly with new version