### PR TITLE
Add column headers to dashboard activity table

### DIFF
--- a/team-ui/src/pages/DashboardPage.tsx
+++ b/team-ui/src/pages/DashboardPage.tsx
@@ -189,6 +189,14 @@ export function DashboardPage() {
                 <p className="text-gray-400 text-sm">No activity yet</p>
               ) : (
                 <table className="w-full">
+                  <thead>
+                    <tr className="border-b border-gray-200">
+                      <th className="py-1.5 pr-3 text-left text-[10px] font-semibold text-gray-400 uppercase w-20">Status</th>
+                      <th className="py-1.5 pr-3 text-left text-[10px] font-semibold text-gray-400 uppercase">Summary</th>
+                      <th className="py-1.5 pr-3 text-right text-[10px] font-semibold text-gray-400 uppercase w-20">Reviewer</th>
+                      <th className="py-1.5 text-right text-[10px] font-semibold text-gray-400 uppercase w-16">Time</th>
+                    </tr>
+                  </thead>
                   <tbody>
                     {stats.recent_activity.map((event, i) => (
                       <tr key={i} className="border-b border-gray-50 last:border-0">


### PR DESCRIPTION
## Summary

- Adds Status, Summary, Reviewer, and Time column headers to the recent activity table on the dashboard
- Styled to match existing table aesthetics (small uppercase, muted colour)

## Test plan

- [ ] Dashboard shows column headers above activity rows
- [ ] Headers align with their respective columns
- [ ] Mobile view: headers remain readable when stacked

Fixes #71