### PR TITLE
Bump plugin version to 0.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "craic",
       "source": "./plugins/craic",
       "description": "Collective Reciprocal Agent Intelligence Commons — shared agent learning",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "category": "knowledge",
       "tags": ["knowledge-sharing", "agent-learning", "agent-commons","mcp", "pitfall-avoidance", "team-knowledge", "api-quirks"]
     }

--- a/plugins/craic/.claude-plugin/plugin.json
+++ b/plugins/craic/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "craic",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Collective Reciprocal Agent Intelligence Commons — shared agent learning",
   "skills": "./skills/",
   "commands": "./commands/",


### PR DESCRIPTION
## Summary

- Bump version in `plugin.json` and `marketplace.json` from 0.2.0 to 0.3.0

### Changes since 0.2.0

- Redesign review UI with drag/swipe interaction model (#67)
- Add column headers to dashboard recent activity table (#72)
- Show promoted_to_team count in craic-status output (#66)
- Deduplicate recent activity to show terminal state only (#73)
- Add activity detail modal to dashboard (#74)
- Add dashboard drilldowns for domains, confidence, and rejected KUs (#75)
- Document environment variable configuration in README (#76)