### PR TITLE
Fix review card clipping during drag

### DIFF
--- a/team-ui/src/components/Layout.tsx
+++ b/team-ui/src/components/Layout.tsx
@@ -41,7 +41,7 @@ export function Layout() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 overflow-x-hidden">
       <nav className="bg-white border-b border-gray-200">
         <div className="max-w-2xl mx-auto px-4 py-3 flex items-center justify-between">
           <div className="flex items-center gap-3 md:gap-6">

--- a/team-ui/src/pages/ReviewPage.tsx
+++ b/team-ui/src/pages/ReviewPage.tsx
@@ -183,7 +183,7 @@ export function ReviewPage() {
   }
 
   return (
-    <div className="overflow-x-hidden">
+    <div>
       {conflictMessage && (
         <p className="text-center text-amber-600 text-sm font-medium mb-3">
           {conflictMessage}


### PR DESCRIPTION
## Summary

- Move `overflow-x-hidden` from ReviewPage wrapper to the root Layout div
- Card was being clipped by the narrow content container (`max-w-2xl`) during drag — the drag indicators appeared at screen edges but the card vanished behind the container boundary
- Now the card visually travels across the full viewport width, and the root div prevents horizontal scrollbars

## Test plan

- [ ] Drag a review card left/right — card should remain visible across full screen width
- [ ] Drag indicators (approve/reject icons) should appear at screen edges as before
- [ ] No horizontal scrollbar appears during or after drag
- [ ] Dashboard and other pages unaffected by the layout change