### PR TITLE
Bump plugin version to 0.3.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "craic",
       "source": "./plugins/craic",
       "description": "Collective Reciprocal Agent Intelligence Commons — shared agent learning",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "category": "knowledge",
       "tags": ["knowledge-sharing", "agent-learning", "agent-commons","mcp", "pitfall-avoidance", "team-knowledge", "api-quirks"]
     }

--- a/plugins/craic/.claude-plugin/plugin.json
+++ b/plugins/craic/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "craic",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Collective Reciprocal Agent Intelligence Commons — shared agent learning",
   "skills": "./skills/",
   "commands": "./commands/",


### PR DESCRIPTION
## Summary

- Bump version in `plugin.json` and `marketplace.json` from 0.3.0 to 0.3.1

### Changes since 0.3.0

- Fix review card clipping during drag (#78)