### PR TITLE
Bump plugin version to 0.3.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "craic",
       "source": "./plugins/craic",
       "description": "Collective Reciprocal Agent Intelligence Commons — shared agent learning",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "category": "knowledge",
       "tags": ["knowledge-sharing", "agent-learning", "agent-commons","mcp", "pitfall-avoidance", "team-knowledge", "api-quirks"]
     }

--- a/plugins/craic/.claude-plugin/plugin.json
+++ b/plugins/craic/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "craic",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Collective Reciprocal Agent Intelligence Commons — shared agent learning",
   "skills": "./skills/",
   "commands": "./commands/",

--- a/plugins/craic/server/pyproject.toml
+++ b/plugins/craic/server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "craic-mcp-server"
-version = "0.3.2"
+version = "0.3.3"
 description = "CRAIC MCP server — shared agent knowledge commons"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

- Bump plugin version to 0.3.3 across marketplace.json, plugin.json, and pyproject.toml.

Covers fix in #91.

## Test plan

- [x] Version strings consistent across all three files