### PR TITLE
Add uninstall instructions for Claude Code and OpenCode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,13 @@ help:
 	@echo ""
 	@echo "Claude Code (recommended):"
 	@echo "  make install-claude                          Install cq plugin"
+	@echo "  make uninstall-claude                        Remove cq plugin"
 	@echo ""
 	@echo "OpenCode:"
 	@echo "  make install-opencode                        Install globally (~/.config/opencode/)"
 	@echo "  make install-opencode PROJECT=/path/to/app   Install into a specific project"
-	@echo "  make uninstall-opencode                      Remove OpenCode install"
+	@echo "  make uninstall-opencode                      Remove global OpenCode install"
+	@echo "  make uninstall-opencode PROJECT=/path/to/app Remove from a specific project"
 	@echo ""
 	@echo "Development:"
 	@echo "  make setup     Install all dependencies"
@@ -35,6 +37,10 @@ setup:
 install-claude:
 	claude plugin marketplace add mozilla-ai/cq
 	claude plugin install cq
+
+.PHONY: uninstall-claude
+uninstall-claude:
+	claude plugin marketplace remove mozilla-ai/cq
 
 .PHONY: install-opencode
 install-opencode:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,26 @@ claude plugin marketplace add mozilla-ai/cq
 claude plugin install cq
 ```
 
+Or from a cloned repo:
+
+```bash
+make install-claude
+```
+
+To uninstall:
+
+```
+claude plugin marketplace remove mozilla-ai/cq
+```
+
+Or from a cloned repo:
+
+```bash
+make uninstall-claude
+```
+
+If you configured team sync, you may also want to remove `CQ_TEAM_ADDR` and `CQ_TEAM_API_KEY` from `~/.claude/settings.json`.
+
 ### OpenCode (MCP server)
 
 Also requires: `jq`
@@ -32,6 +52,16 @@ Or for a specific project:
 ```bash
 make install-opencode PROJECT=/path/to/your/project
 ```
+
+To uninstall:
+
+```bash
+make uninstall-opencode
+# or for a specific project:
+make uninstall-opencode PROJECT=/path/to/your/project
+```
+
+If you configured team sync, you may also want to remove the `environment` block from the cq entry in your OpenCode config.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

- Add `make uninstall-claude` target wrapping `claude plugin marketplace remove mozilla-ai/cq`
- Document uninstall steps for both Claude Code and OpenCode in README
- Add team sync cleanup notes (env vars / environment block removal)

## Test plan

- [x] `make help` shows `uninstall-claude` target
- [ ] `make uninstall-claude` runs the correct plugin remove command
- [ ] README uninstall sections render correctly