### PR TITLE
Fix dashboard graph: gap-fill dates, add approval/rejection lines

### DIFF
--- a/team-api/team_api/review.py
+++ b/team-api/team_api/review.py
@@ -37,10 +37,12 @@ class ReviewDecisionResponse(BaseModel):
 
 
 class DailyCount(BaseModel):
-    """Daily proposal count."""
+    """Daily proposal, approval, and rejection counts."""
 
     date: str
     proposed: int
+    approved: int
+    rejected: int
 
 
 class TrendsResponse(BaseModel):

--- a/team-api/team_api/store.py
+++ b/team-api/team_api/store.py
@@ -7,7 +7,7 @@ Implements the context manager protocol for deterministic resource cleanup.
 
 import sqlite3
 import threading
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import TracebackType
 from typing import Any
@@ -578,15 +578,18 @@ class TeamStore:
         return activity[:limit]
 
     def daily_counts(self, *, days: int = 30) -> list[dict[str, Any]]:
-        """Return daily proposal counts for the last N days.
+        """Return daily proposal and approval counts with contiguous dates.
 
-        Pre-migration rows with NULL created_at are excluded from counts.
+        Returns one entry per day from the earliest activity (within the
+        lookback window) through today, filling gaps with zero counts.
+        Pre-migration rows with NULL created_at are excluded.
 
         Args:
             days: Number of days to look back.
 
         Returns:
-            List of dicts with date and proposed count, ordered ascending.
+            List of dicts with date, proposed, approved, and rejected
+            counts, ordered ascending.
 
         Raises:
             ValueError: If days is not positive.
@@ -594,12 +597,50 @@ class TeamStore:
         if days <= 0:
             raise ValueError("days must be positive")
         self._check_open()
+        cutoff = f"-{days} days"
         with self._lock:
-            rows = self._conn.execute(
-                "SELECT date(created_at) as day, COUNT(*) as proposed "
+            proposed_rows = self._conn.execute(
+                "SELECT date(created_at) as day, COUNT(*) as cnt "
                 "FROM knowledge_units "
                 "WHERE created_at >= date('now', ?) "
-                "GROUP BY day ORDER BY day ASC",
-                (f"-{days} days",),
+                "GROUP BY day",
+                (cutoff,),
             ).fetchall()
-        return [{"date": row[0], "proposed": row[1]} for row in rows]
+            approved_rows = self._conn.execute(
+                "SELECT date(reviewed_at) as day, COUNT(*) as cnt "
+                "FROM knowledge_units "
+                "WHERE status = 'approved' "
+                "AND reviewed_at >= date('now', ?) "
+                "GROUP BY day",
+                (cutoff,),
+            ).fetchall()
+            rejected_rows = self._conn.execute(
+                "SELECT date(reviewed_at) as day, COUNT(*) as cnt "
+                "FROM knowledge_units "
+                "WHERE status = 'rejected' "
+                "AND reviewed_at >= date('now', ?) "
+                "GROUP BY day",
+                (cutoff,),
+            ).fetchall()
+        proposed = {row[0]: row[1] for row in proposed_rows}
+        approved = {row[0]: row[1] for row in approved_rows}
+        rejected = {row[0]: row[1] for row in rejected_rows}
+        all_dates = set(proposed) | set(approved) | set(rejected)
+        if not all_dates:
+            return []
+        start = min(datetime.strptime(d, "%Y-%m-%d").date() for d in all_dates)
+        end = datetime.now(UTC).date()
+        result: list[dict[str, Any]] = []
+        current = start
+        while current <= end:
+            key = current.isoformat()
+            result.append(
+                {
+                    "date": key,
+                    "proposed": proposed.get(key, 0),
+                    "approved": approved.get(key, 0),
+                    "rejected": rejected.get(key, 0),
+                }
+            )
+            current += timedelta(days=1)
+        return result

--- a/team-api/tests/test_store.py
+++ b/team-api/tests/test_store.py
@@ -2,6 +2,7 @@
 
 import sqlite3
 from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -268,6 +269,95 @@ class TestReviewQueue:
         assert len(counts) >= 1
         total = sum(row["proposed"] for row in counts)
         assert total == 2
+
+    def test_daily_counts_gap_fills_to_today(self, store: TeamStore) -> None:
+        """daily_counts should return contiguous dates from the earliest entry to today."""
+        three_days_ago = datetime.now(UTC) - timedelta(days=3)
+        unit = _make_unit(domain=["a"])
+        unit.evidence.first_observed = three_days_ago
+        unit.evidence.last_confirmed = three_days_ago
+        store.insert(unit)
+
+        counts = store.daily_counts(days=30)
+
+        dates = [row["date"] for row in counts]
+        today_str = datetime.now(UTC).strftime("%Y-%m-%d")
+        three_days_ago_str = three_days_ago.strftime("%Y-%m-%d")
+
+        # Should include every date from the earliest entry through today.
+        assert dates[0] == three_days_ago_str
+        assert dates[-1] == today_str
+        assert len(dates) == 4  # 3 days ago, 2 days ago, yesterday, today
+
+        # Only the first date has a proposal; rest should be zero.
+        assert counts[0]["proposed"] == 1
+        for row in counts[1:]:
+            assert row["proposed"] == 0
+
+    def test_daily_counts_includes_approved(self, store: TeamStore) -> None:
+        """daily_counts should include approved counts grouped by reviewed_at date."""
+        three_days_ago = datetime.now(UTC) - timedelta(days=3)
+        one_day_ago = datetime.now(UTC) - timedelta(days=1)
+
+        u1 = _make_unit(domain=["a"])
+        u1.evidence.first_observed = three_days_ago
+        u1.evidence.last_confirmed = three_days_ago
+        store.insert(u1)
+
+        u2 = _make_unit(domain=["b"])
+        u2.evidence.first_observed = three_days_ago
+        u2.evidence.last_confirmed = three_days_ago
+        store.insert(u2)
+
+        store.set_review_status(u1.id, "approved", "reviewer")
+        # Backdate reviewed_at to 1 day ago.
+        with store._lock, store._conn:
+            store._conn.execute(
+                "UPDATE knowledge_units SET reviewed_at = ? WHERE id = ?",
+                (one_day_ago.isoformat(), u1.id),
+            )
+
+        counts = store.daily_counts(days=30)
+        by_date = {row["date"]: row for row in counts}
+
+        three_days_ago_str = three_days_ago.strftime("%Y-%m-%d")
+        one_day_ago_str = one_day_ago.strftime("%Y-%m-%d")
+
+        # Both units were proposed 3 days ago.
+        assert by_date[three_days_ago_str]["proposed"] == 2
+        # One was approved 1 day ago.
+        assert by_date[one_day_ago_str]["approved"] == 1
+        # No approvals on the proposal date.
+        assert by_date[three_days_ago_str]["approved"] == 0
+
+    def test_daily_counts_includes_rejected(self, store: TeamStore) -> None:
+        """daily_counts should include rejected counts grouped by reviewed_at date."""
+        two_days_ago = datetime.now(UTC) - timedelta(days=2)
+
+        unit = _make_unit(domain=["a"])
+        unit.evidence.first_observed = two_days_ago
+        unit.evidence.last_confirmed = two_days_ago
+        store.insert(unit)
+
+        store.set_review_status(unit.id, "rejected", "reviewer")
+        # Backdate reviewed_at to today.
+        today = datetime.now(UTC)
+        with store._lock, store._conn:
+            store._conn.execute(
+                "UPDATE knowledge_units SET reviewed_at = ? WHERE id = ?",
+                (today.isoformat(), unit.id),
+            )
+
+        counts = store.daily_counts(days=30)
+        by_date = {row["date"]: row for row in counts}
+
+        today_str = today.strftime("%Y-%m-%d")
+        two_days_ago_str = two_days_ago.strftime("%Y-%m-%d")
+
+        assert by_date[two_days_ago_str]["proposed"] == 1
+        assert by_date[two_days_ago_str]["rejected"] == 0
+        assert by_date[today_str]["rejected"] == 1
+        assert by_date[today_str]["proposed"] == 0
 
     def test_daily_counts_rejects_non_positive_days(self, store: TeamStore) -> None:
         with pytest.raises(ValueError, match="days must be positive"):

--- a/team-ui/src/pages/DashboardPage.tsx
+++ b/team-ui/src/pages/DashboardPage.tsx
@@ -1,27 +1,13 @@
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Link, useOutletContext } from "react-router";
-import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
+import { LineChart, Line, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer } from "recharts";
 import { api } from "../api";
 import { StatusBadge } from "../components/StatusBadge";
 import { KnowledgeUnitModal } from "../components/KnowledgeUnitModal";
 import { FilteredListModal, type ListFilter } from "../components/FilteredListModal";
 import { timeAgo } from "../utils";
-import type { ReviewStatsResponse, DailyCount } from "../types";
+import type { ReviewStatsResponse } from "../types";
 
-function useCumulativeTotals(daily: DailyCount[]) {
-  return useMemo(() => {
-    const data = daily.reduce<Array<DailyCount & { total: number }>>((acc, d) => {
-      const total = (acc.length > 0 ? acc[acc.length - 1].total : 0) + d.proposed;
-      acc.push({ ...d, total });
-      return acc;
-    }, []);
-    // Prepend an origin point so a single day draws a line from zero.
-    if (data.length > 0) {
-      data.unshift({ date: "", proposed: 0, total: 0 });
-    }
-    return data;
-  }, [daily]);
-}
 
 const CONFIDENCE_COLORS: Record<string, string> = {
   "0.0-0.3": "bg-red-200",
@@ -57,7 +43,7 @@ export function DashboardPage() {
     return () => clearInterval(interval);
   }, [setPendingCount]);
 
-  const trendData = useCumulativeTotals(stats?.trends.daily ?? []);
+  const trendData = stats?.trends.daily ?? [];
 
   if (!stats && !error) {
     return (
@@ -193,22 +179,30 @@ export function DashboardPage() {
                   <XAxis dataKey="date" tick={{ fontSize: 10 }} />
                   <YAxis tick={{ fontSize: 10 }} allowDecimals={false} />
                   <Tooltip />
+                  <Legend wrapperStyle={{ fontSize: 11 }} />
                   <Line
                     type="monotone"
                     dataKey="proposed"
-                    stroke="#6366f1"
+                    stroke="#eab308"
                     strokeWidth={2}
                     dot={trendData.length <= 7}
-                    name="Daily proposals"
+                    name="Submitted"
                   />
                   <Line
                     type="monotone"
-                    dataKey="total"
-                    stroke="#9ca3af"
-                    strokeWidth={1.5}
-                    strokeDasharray="5 5"
+                    dataKey="approved"
+                    stroke="#22c55e"
+                    strokeWidth={2}
                     dot={trendData.length <= 7}
-                    name="Cumulative total"
+                    name="Approved"
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="rejected"
+                    stroke="#ef4444"
+                    strokeWidth={2}
+                    dot={trendData.length <= 7}
+                    name="Rejected"
                   />
                 </LineChart>
               </ResponsiveContainer>

--- a/team-ui/src/types.ts
+++ b/team-ui/src/types.ts
@@ -62,6 +62,8 @@ export interface ActivityEvent {
 export interface DailyCount {
   date: string;
   proposed: number;
+  approved: number;
+  rejected: number;
 }
 
 export interface ReviewStatsResponse {


### PR DESCRIPTION
## Summary

- **Fix:** `daily_counts()` only returned rows for days with proposals (no gap-filling), so the graph showed a single point when all items were proposed on the same day. The activity feed showed review timestamps, making it look like data was missing.
- **Enhancement:** Gap-fill the date range from earliest activity through today. Add approved and rejected series grouped by `reviewed_at` date.
- **UI:** Chart now shows three colour-coded lines (yellow=submitted, green=approved, red=rejected) with a legend.

## Test plan

- [x] New tests: gap-filling, approved counts by date, rejected counts by date
- [x] Full test suite passes (267 tests)
- [x] Lint and typecheck pass
- [x] Manual: verify graph shows contiguous dates with multiple lines after proposing/reviewing items on different days