### PR TITLE
Bump plugin version to 0.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "cq",
       "source": "./plugins/cq",
       "description": "Shared knowledge commons for AI agents; find, share, and confirm collective knowledge to stop rediscovering the same failures.",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "category": "knowledge",
       "tags": ["knowledge-sharing", "agent-learning", "agent-commons","mcp", "pitfall-avoidance", "team-knowledge", "api-quirks"]
     }

--- a/plugins/cq/.claude-plugin/plugin.json
+++ b/plugins/cq/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cq",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Shared knowledge commons for AI agents; find, share, and confirm collective knowledge to stop rediscovering the same failures.",
   "skills": "./skills/",
   "commands": "./commands/",

--- a/plugins/cq/server/pyproject.toml
+++ b/plugins/cq/server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cq-mcp-server"
-version = "0.3.3"
+version = "0.4.0"
 description = "cq MCP server — shared agent knowledge commons"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

- Bumps version from `0.3.3` to `0.4.0` across `plugin.json`, `pyproject.toml`, and `marketplace.json`
- Reflects the breaking change in #148 (MCP tool names renamed from `cq_X` to `X`)

## Test plan

- [ ] Merge #148 first, then merge this