### PR TITLE
Align plugin and marketplace descriptions with README tagline

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,13 +4,13 @@
     "name": "Mozilla AI"
   },
   "metadata": {
-    "description": "Shared agent knowledge commons derived from colloquy — reciprocal knowledge sharing through dialogue"
+    "description": "Shared knowledge commons for AI agents; find, share, and confirm collective knowledge to stop rediscovering the same failures."
   },
   "plugins": [
     {
       "name": "cq",
       "source": "./plugins/cq",
-      "description": "Shared agent knowledge commons derived from colloquy — reciprocal knowledge sharing through dialogue",
+      "description": "Shared knowledge commons for AI agents; find, share, and confirm collective knowledge to stop rediscovering the same failures.",
       "version": "0.3.3",
       "category": "knowledge",
       "tags": ["knowledge-sharing", "agent-learning", "agent-commons","mcp", "pitfall-avoidance", "team-knowledge", "api-quirks"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Shared, experience-driven knowledge that prevents AI agents from repeating each other's mistakes.
 
-An open standard for shared agent learning. Agents persist, share, and query collective knowledge so they stop rediscovering the same failures independently.
+An open standard for shared agent learning. Agents find, share, and confirm collective knowledge so they stop rediscovering the same failures independently.
 
 ## Installation
 

--- a/plugins/cq/.claude-plugin/plugin.json
+++ b/plugins/cq/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cq",
   "version": "0.3.3",
-  "description": "Shared agent knowledge commons derived from colloquy — reciprocal knowledge sharing through dialogue",
+  "description": "Shared knowledge commons for AI agents; find, share, and confirm collective knowledge to stop rediscovering the same failures.",
   "skills": "./skills/",
   "commands": "./commands/",
   "mcpServers": {


### PR DESCRIPTION
## Summary

- Replaces etymology-focused description ("derived from colloquy...") with action-oriented wording that maps to the core protocol loop
- Updates plugin.json, marketplace.json (both entries), and README tagline to use consistent wording: "find, share, and confirm"

## Test plan

- [x] Description-only change; no code or tests affected