### PR TITLE
Fix marketplace uninstall command plugin name

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ make install-claude
 To uninstall:
 
 ```
-claude plugin marketplace remove mozilla-ai/cq
+claude plugin marketplace remove cq
 ```
 
 Or from a cloned repo:


### PR DESCRIPTION
## Summary

Fix the `claude plugin marketplace remove` command in README to use the short plugin name `cq` instead of `mozilla-ai/cq`

## Test plan
- [x] Verify `claude plugin marketplace remove cq` works correctly