### PR TITLE
Fix FTS5 query injection in local store

### DIFF
--- a/plugins/cq/server/cq_mcp/local_store.py
+++ b/plugins/cq/server/cq_mcp/local_store.py
@@ -356,7 +356,11 @@ class LocalStore:
                 try:
                     fts_rows = self._conn.execute(fts_sql, (fts_terms,)).fetchall()
                 except sqlite3.OperationalError:
-                    logger.warning("FTS query failed for expression: %s", fts_terms)
+                    logger.warning(
+                        "FTS query failed (expression length=%d chars)",
+                        len(fts_terms),
+                        exc_info=True,
+                    )
 
         # Merge and deduplicate by ID.
         seen: set[str] = set()

--- a/plugins/cq/server/tests/test_local_store.py
+++ b/plugins/cq/server/tests/test_local_store.py
@@ -41,7 +41,7 @@ def _make_unit(**overrides: Any) -> KnowledgeUnit:
 
 
 def _inspect_connection(db_path: Path) -> sqlite3.Connection:
-    """Open a test inspection connection with production-matching pragmas."""
+    """Open a test inspection connection with foreign key enforcement enabled."""
     conn = sqlite3.connect(str(db_path))
     conn.execute("PRAGMA foreign_keys = ON")
     return conn


### PR DESCRIPTION
## Summary

- Domain tags containing double quotes broke the FTS5 MATCH expression, silently dropping search results. Extract `_build_fts_match_expr()` as an isolated, well-tested security boundary.
- Add term count (`_FTS_MAX_TERMS=20`) and length (`_FTS_MAX_TERM_LENGTH=200`) guardrails against resource exhaustion.
- Verify FK pragma took effect on connection open (load-bearing for CASCADE).
- Remove redundant manual `DELETE FROM knowledge_unit_domains` in `delete()`; rely on `ON DELETE CASCADE`.
- Fix `fts_rows` type annotation (`tuple[str]` -> `tuple[Any, ...]`).
- Align test inspection helpers with production pragmas (`PRAGMA foreign_keys = ON`).
- Rename misleading test `test_fts_query_all_terms_sanitise_to_empty` -> `test_fts_query_empty_match_expr_does_not_crash`.

## Test plan

- [x] 24 new tests for `_build_fts_match_expr` (clean terms, injection attempts, guardrails, exact output pins)
- [x] 12 new FTS integration tests (quote poisoning, adversarial inputs, empty expressions)
- [x] Full suite: 302 tests passing (207 server + 95 team-api), lint clean, type checks clean
- [x] Star-Chamber multi-LLM review (2-round debate: OpenAI, Anthropic, Gemini) — all feedback addressed