### PR TITLE
Fix incorrect copywrite naming in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2026 Peter Wilson
+   Copyright 2026 Mozilla AI
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Showed incorrect 'Peter Wilson' from earlier iterations, but should be 'Mozilla AI'.