### PR TITLE
Add support for cursor

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,7 +6,7 @@
 - [uv](https://docs.astral.sh/uv/)
 - [pnpm](https://pnpm.io/)
 - Docker and Docker Compose
-- jq (only needed for `make install-opencode`)
+- jq (only needed for `make install-cursor` / `make install-opencode`)
 
 ## Repository Structure
 
@@ -62,6 +62,24 @@ Add to `~/.claude/settings.json` under the `env` key:
 {
   "env": {
     "CQ_TEAM_ADDR": "http://localhost:8742"
+  }
+}
+```
+
+### Cursor
+
+Add to `.cursor/mcp.json` (global `~/.cursor/mcp.json` or project-level), inside the cq server's `env` key:
+
+```json
+{
+  "mcpServers": {
+    "cq": {
+      "command": "uv",
+      "args": ["run", "--directory", "/path/to/cq/plugins/cq/server", "cq-mcp-server"],
+      "env": {
+        "CQ_TEAM_ADDR": "http://localhost:8742"
+      }
+    }
   }
 }
 ```

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,12 @@ help:
 	@echo "  make install-claude                          Install cq plugin"
 	@echo "  make uninstall-claude                        Remove cq plugin"
 	@echo ""
+	@echo "Cursor:"
+	@echo "  make install-cursor                          Install globally (~/.cursor/)"
+	@echo "  make install-cursor PROJECT=/path/to/app     Install into a specific project"
+	@echo "  make uninstall-cursor                        Remove global Cursor install"
+	@echo "  make uninstall-cursor PROJECT=/path/to/app   Remove from a specific project"
+	@echo ""
 	@echo "OpenCode:"
 	@echo "  make install-opencode                        Install globally (~/.config/opencode/)"
 	@echo "  make install-opencode PROJECT=/path/to/app   Install into a specific project"
@@ -53,6 +59,22 @@ install-claude:
 .PHONY: uninstall-claude
 uninstall-claude:
 	claude plugin marketplace remove mozilla-ai/cq
+
+.PHONY: install-cursor
+install-cursor:
+ifdef PROJECT
+	@bash "$(CURDIR)/scripts/install-cursor.sh" install --project "$(PROJECT)"
+else
+	@bash "$(CURDIR)/scripts/install-cursor.sh" install
+endif
+
+.PHONY: uninstall-cursor
+uninstall-cursor:
+ifdef PROJECT
+	@bash "$(CURDIR)/scripts/install-cursor.sh" uninstall --project "$(PROJECT)"
+else
+	@bash "$(CURDIR)/scripts/install-cursor.sh" uninstall
+endif
 
 .PHONY: install-opencode
 install-opencode:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,38 @@ make uninstall-claude
 
 If you configured team sync, you may also want to remove `CQ_TEAM_ADDR` and `CQ_TEAM_API_KEY` from `~/.claude/settings.json`.
 
+### Cursor (MCP server + skill + rule)
+
+Also requires: `jq`
+
+```bash
+git clone https://github.com/mozilla-ai/cq.git
+cd cq
+make install-cursor
+```
+
+Or for a specific project:
+
+```bash
+make install-cursor PROJECT=/path/to/your/project
+```
+
+This installs:
+- **MCP server** — registered in `.cursor/mcp.json`
+- **cq skill** — symlinked into `.cursor/skills/cq/`
+- **Cursor rule** — `.cursor/rules/cq.mdc` (agent-decided, prompts skill loading)
+- **Session start hook** — `.cursor/hooks.json` (pre-syncs Python dependencies)
+
+To uninstall:
+
+```bash
+make uninstall-cursor
+# or for a specific project:
+make uninstall-cursor PROJECT=/path/to/your/project
+```
+
+If you configured team sync, you may also want to remove `CQ_TEAM_ADDR` and `CQ_TEAM_API_KEY` from `.cursor/mcp.json` env.
+
 ### OpenCode (MCP server)
 
 Also requires: `jq`
@@ -123,6 +155,27 @@ Add variables to `~/.claude/settings.json` under the `env` key:
   }
 }
 ```
+
+### Cursor
+
+Add an `env` key to the cq MCP server entry in `.cursor/mcp.json` (global `~/.cursor/mcp.json` or project-level `<project>/.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "cq": {
+      "command": "uv",
+      "args": ["run", "--directory", "/path/to/cq/plugins/cq/server", "cq-mcp-server"],
+      "env": {
+        "CQ_TEAM_ADDR": "http://localhost:8742",
+        "CQ_TEAM_API_KEY": "your-api-key"
+      }
+    }
+  }
+}
+```
+
+Alternatively, export the variables in your shell before launching Cursor.
 
 ### OpenCode
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,11 @@ This installs:
 - **MCP server** — registered in `.cursor/mcp.json`
 - **cq skill** — symlinked into `.cursor/skills/cq/`
 - **Cursor rule** — `.cursor/rules/cq.mdc` (agent-decided, prompts skill loading)
-- **Session start hook** — `.cursor/hooks.json` (pre-syncs Python dependencies)
+- **Cursor hooks** — `.cursor/hooks.json` with:
+  - `sessionStart` to pre-sync Python dependencies and set per-session hook state
+  - `postToolUseFailure` to record the last failed tool call
+  - `postToolUse` to clear stale failure state once the agent recovers
+  - `stop` to auto-submit a cq follow-up when the agent loop ends immediately after a tool failure
 
 To uninstall:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,16 +6,16 @@ This document describes the architecture of cq (shared agent knowledge commons) 
 
 ## 1. System Overview
 
-cq runs across three distinct runtime boundaries. Claude Code loads the plugin configuration files that shape agent behaviour. A local MCP server process handles all cq logic and owns the private knowledge store. A Docker container runs the Team API independently for shared organisational knowledge.
+cq runs across three distinct runtime boundaries. A host agent loads the configuration files that shape agent behaviour. A local MCP server process handles all cq logic and owns the private knowledge store. A Docker container runs the Team API independently for shared organisational knowledge.
 
 ```mermaid
 flowchart TB
-    subgraph cc["Claude Code Process"]
+    subgraph cc["Host Agent Process"]
         direction TB
         skill["SKILL.md\nBehavioural instructions"]
-        hook["hooks.json\nPost-error auto-query"]
-        cmd_status["/cq:status\nStore statistics"]
-        cmd_reflect["/cq:reflect\nSession mining"]
+        hook["Host hooks / automation\nSession bootstrap +\nerror follow-up"]
+        cmd_status["Host commands / entrypoints\nStatus and reflection"]
+        cmd_reflect["Agent loop / UX surface"]
     end
 
     subgraph mcp["Local MCP Server Process"]
@@ -46,9 +46,9 @@ flowchart TB
     class local_db,team_db dbStyle
 ```
 
-**Claude Code** loads markdown and JSON configuration files. No cq code runs inside the agent process itself.
+**Host Agent** loads markdown and JSON configuration files. No cq code runs inside the agent process itself.
 
-**MCP Server** is spawned by Claude Code via stdio. It runs FastMCP, exposes five tools, and owns the local SQLite store (default: `$XDG_DATA_HOME/cq/local.db`, typically `~/.local/share/cq/local.db`).
+**MCP Server** is spawned by the host agent via stdio. It runs FastMCP, exposes six tools, and owns the local SQLite store (default: `$XDG_DATA_HOME/cq/local.db`, typically `~/.local/share/cq/local.db`).
 
 **Docker Container** runs the Team API as an independent service (`docker compose up`). In production this would be a hosted service with authentication, tenancy, and RBAC.
 
@@ -346,18 +346,18 @@ The API contract — how agents read and write knowledge units via MCP tools —
 
 ## 4. Plugin Anatomy
 
-The cq plugin bundles everything an agent needs into a single installable unit. Each component serves a distinct role.
+The cq distribution bundles the components an agent host needs into an installable unit. Different hosts may consume different subsets, but each component serves a distinct role.
 
 ```mermaid
 flowchart LR
     subgraph plugin["cq Plugin"]
         direction TB
-        manifest["plugin.json\nWires everything together"]
+        manifest["plugin.json / install scripts\nWire host integrations\ntogether"]
         skill["SKILL.md\nTeaches agent when to\nquery, propose, confirm, flag"]
         reviewer["cq-reviewer.md\nSub-agent for reviewing\ngraduation candidates"]
         mcp_cfg[".mcp.json\nMCP server configuration"]
-        hooks["hooks.json\nSession start sync +\nfailed-tool follow-up"]
-        commands["Commands\n/cq:status — store stats\n/cq:reflect — session mining"]
+        hooks["Host hooks / automation\nBootstrap +\nfailed-tool follow-up"]
+        commands["Host commands / entrypoints\nStatus + reflection"]
     end
 
     subgraph server["MCP Server"]
@@ -384,11 +384,15 @@ flowchart LR
 
 **MCP Server** exposes six tools over stdio. The agent calls these tools based on the Skill's instructions. The server handles local storage, team API communication, confidence scoring, and query matching.
 
-**Hooks** trigger automatically. In Cursor, the session-start hook pre-syncs the cq MCP server environment and sets per-session hook state. A `postToolUseFailure` hook records the last failed tool call, and a `stop` hook can auto-submit a cq follow-up when the agent loop ends immediately after that failure. This mirrors the "query before retrying" intent without relying on unsupported output fields from Cursor's failure hook.
+**Hooks** are the lifecycle automation layer when the host supports them. They bootstrap per-session state, capture tool-failure context, clear stale failure state after recovery, and can inject follow-up guidance when the agent loop ends immediately after an unrecovered failure.
 
-**Commands** are developer-facing. `/cq:status` shows store statistics. `/cq:reflect` triggers retrospective session mining — it catches long-tail knowledge that real-time hooks miss, ranks candidates by estimated generalisability, and checks the commons for existing coverage before proposing (surfacing existing KUs rather than creating duplicates). Candidates are presented for human approval.
+Host-specific implementations diverge:
+- **Cursor** uses `.cursor/hooks.json` with `sessionStart`, `postToolUseFailure`, `postToolUse`, and `stop` hooks. Together these pre-sync the cq MCP environment, record the last failed tool call, clear stale failure state after recovery, and auto-submit a cq follow-up when the agent loop ends immediately after a failure.
+- **Claude Code** in this repo does not ship a separate hook configuration file. The same "query before retrying" behaviour is primarily carried by `SKILL.md`, with plugin commands and MCP tools providing the agent-facing surfaces.
 
-**plugin.json** is the manifest that declares all components and wires them together for one-command installation.
+**Commands** are developer-facing entrypoints where the host exposes them. In Claude Code, `/cq:status` shows store statistics and `/cq:reflect` triggers retrospective session mining. Cursor currently relies on the MCP tools, Skill, rule, and hooks instead of installing equivalent slash commands from this repo.
+
+**plugin.json** is one host-specific packaging surface. Other hosts may be wired up by installation scripts and host-native configuration files instead of a plugin manifest.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -356,7 +356,7 @@ flowchart LR
         skill["SKILL.md\nTeaches agent when to\nquery, propose, confirm, flag"]
         reviewer["cq-reviewer.md\nSub-agent for reviewing\ngraduation candidates"]
         mcp_cfg[".mcp.json\nMCP server configuration"]
-        hooks["hooks.json\nPost-error: auto-query\ncommons on failure"]
+        hooks["hooks.json\nSession start sync +\nfailed-tool follow-up"]
         commands["Commands\n/cq:status — store stats\n/cq:reflect — session mining"]
     end
 
@@ -384,7 +384,7 @@ flowchart LR
 
 **MCP Server** exposes six tools over stdio. The agent calls these tools based on the Skill's instructions. The server handles local storage, team API communication, confidence scoring, and query matching.
 
-**Hooks** trigger automatically. The post-error hook instructs the agent to call `query` with the error context before attempting a fix.
+**Hooks** trigger automatically. In Cursor, the session-start hook pre-syncs the cq MCP server environment and sets per-session hook state. A `postToolUseFailure` hook records the last failed tool call, and a `stop` hook can auto-submit a cq follow-up when the agent loop ends immediately after that failure. This mirrors the "query before retrying" intent without relying on unsupported output fields from Cursor's failure hook.
 
 **Commands** are developer-facing. `/cq:status` shows store statistics. `/cq:reflect` triggers retrospective session mining — it catches long-tail knowledge that real-time hooks miss, ranks candidates by estimated generalisability, and checks the commons for existing coverage before proposing (surfacing existing KUs rather than creating duplicates). Candidates are presented for human approval.
 

--- a/plugins/cq/hooks/cursor/cq_cursor_hook.py
+++ b/plugins/cq/hooks/cursor/cq_cursor_hook.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Cursor hook helpers for cq.
+
+This script uses only the Python standard library so it can run before the
+cq MCP server environment has been synced.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any
+
+STATE_FILE_ENV = "CQ_CURSOR_CQ_STATE_FILE"
+STATE_DIR_NAME = "cq-hook-state"
+MAX_SNIPPET_LEN = 240
+
+
+def _read_payload() -> dict[str, Any]:
+    raw = sys.stdin.read().strip()
+    if not raw:
+        return {}
+    return json.loads(raw)
+
+
+def _write_response(payload: dict[str, Any]) -> int:
+    sys.stdout.write(json.dumps(payload) + "\n")
+    return 0
+
+
+def _state_file() -> Path | None:
+    raw_path = os.environ.get(STATE_FILE_ENV, "").strip()
+    if not raw_path:
+        return None
+    return Path(raw_path)
+
+
+def _load_state(path: Path | None) -> dict[str, Any]:
+    if path is None or not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return {}
+
+
+def _save_state(path: Path | None, state: dict[str, Any]) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state))
+
+
+def _clear_state(path: Path | None) -> None:
+    if path is None:
+        return
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+
+
+def _truncate(value: Any) -> str:
+    text = str(value).strip()
+    if len(text) <= MAX_SNIPPET_LEN:
+        return text
+    return text[: MAX_SNIPPET_LEN - 3] + "..."
+
+
+def _format_tool_input(tool_name: str, tool_input: Any) -> str:
+    if not isinstance(tool_input, dict):
+        return ""
+    if tool_name == "Shell":
+        command = tool_input.get("command", "")
+        if command:
+            return f" command=`{_truncate(command)}`"
+    return ""
+
+
+def run_session_start(server_dir: str, uv_bin: str) -> int:
+    payload = _read_payload()
+    session_id = str(payload.get("session_id", "")).strip()
+    if not session_id:
+        return _write_response({})
+
+    state_dir = Path.home() / ".cursor" / STATE_DIR_NAME
+    state_file = state_dir / f"{session_id}.json"
+    _clear_state(state_file)
+
+    response: dict[str, Any] = {
+        "env": {
+            STATE_FILE_ENV: str(state_file),
+        }
+    }
+
+    proc = subprocess.run(
+        [uv_bin, "sync", "--directory", server_dir, "--quiet"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        stderr = _truncate(proc.stderr or proc.stdout or "unknown error")
+        response["additional_context"] = (
+            "cq Cursor session setup could not sync the cq MCP server "
+            f"environment. Command: `{uv_bin} sync --directory {server_dir} "
+            f"--quiet`. Error: {stderr}"
+        )
+
+    return _write_response(response)
+
+
+def run_post_tool_use() -> int:
+    _read_payload()
+    _clear_state(_state_file())
+    return _write_response({})
+
+
+def run_post_tool_use_failure() -> int:
+    payload = _read_payload()
+    if payload.get("is_interrupt"):
+        return _write_response({})
+
+    tool_name = str(payload.get("tool_name", "")).strip()
+    if tool_name == "MCP: cq":
+        return _write_response({})
+
+    state = {
+        "tool_name": tool_name,
+        "failure_type": str(payload.get("failure_type", "")).strip(),
+        "error_message": _truncate(payload.get("error_message", "")),
+        "cwd": _truncate(payload.get("cwd", "")),
+        "tool_context": _format_tool_input(tool_name, payload.get("tool_input")),
+    }
+    _save_state(_state_file(), state)
+    return _write_response({})
+
+
+def run_stop() -> int:
+    payload = _read_payload()
+    if payload.get("status") != "error" or payload.get("loop_count", 0) != 0:
+        _clear_state(_state_file())
+        return _write_response({})
+
+    state = _load_state(_state_file())
+    _clear_state(_state_file())
+    if not state:
+        return _write_response({})
+
+    tool_name = state.get("tool_name") or "unknown"
+    failure_type = state.get("failure_type") or "error"
+    error_message = state.get("error_message") or "unknown error"
+    cwd = state.get("cwd")
+    tool_context = state.get("tool_context", "")
+
+    location = f" cwd=`{cwd}`" if cwd else ""
+    followup = (
+        "A tool just failed and the agent loop ended. Before retrying, load "
+        "the `cq` skill if it is available and query `cq` using domain tags "
+        "derived from this failure context instead of retrying blindly. "
+        f"Recent failure: tool=`{tool_name}` type=`{failure_type}`"
+        f"{tool_context}{location} error=`{error_message}`."
+    )
+    return _write_response({"followup_message": followup})
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--mode",
+        required=True,
+        choices=("session-start", "post-tool-use", "post-tool-use-failure", "stop"),
+    )
+    parser.add_argument("--server-dir", default="")
+    parser.add_argument("--uv-bin", default="uv")
+    args = parser.parse_args()
+
+    if args.mode == "session-start":
+        return run_session_start(args.server_dir, args.uv_bin)
+    if args.mode == "post-tool-use":
+        return run_post_tool_use()
+    if args.mode == "post-tool-use-failure":
+        return run_post_tool_use_failure()
+    return run_stop()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/_install-common.sh
+++ b/scripts/_install-common.sh
@@ -3,7 +3,7 @@
 # Sourced by install-cursor.sh and install-opencode.sh.
 #
 # Provides: SCRIPT_DIR, REPO_ROOT, PLUGIN_DIR, SERVER_DIR, ACTION, PROJECT,
-#           apply(), usage(), and jq dependency check.
+#           UV_BIN, apply(), usage(), and dependency checks.
 #
 # The sourcing script must set TARGET after sourcing this file.
 
@@ -18,6 +18,12 @@ SERVER_DIR="${PLUGIN_DIR}/server"
 
 if ! command -v jq &>/dev/null; then
     echo "Error: jq is required. Install with: brew install jq" >&2
+    exit 1
+fi
+
+UV_BIN="$(command -v uv || true)"
+if [[ -z "${UV_BIN}" ]]; then
+    echo "Error: uv is required. Install from: https://docs.astral.sh/uv/" >&2
     exit 1
 fi
 

--- a/scripts/_install-common.sh
+++ b/scripts/_install-common.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Shared helpers for cq install scripts.
+# Sourced by install-cursor.sh and install-opencode.sh.
+#
+# Provides: SCRIPT_DIR, REPO_ROOT, PLUGIN_DIR, SERVER_DIR, ACTION, PROJECT,
+#           apply(), usage(), and jq dependency check.
+#
+# The sourcing script must set TARGET after sourcing this file.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[1]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PLUGIN_DIR="${REPO_ROOT}/plugins/cq"
+SERVER_DIR="${PLUGIN_DIR}/server"
+
+# -- Dependencies. --
+
+if ! command -v jq &>/dev/null; then
+    echo "Error: jq is required. Install with: brew install jq" >&2
+    exit 1
+fi
+
+# -- Argument parsing. --
+
+usage() {
+    echo "Usage: $(basename "${BASH_SOURCE[1]}") <install|uninstall> [--project <path>]"
+    exit 1
+}
+
+if [[ $# -lt 1 ]]; then
+    usage
+fi
+
+ACTION="$1"
+shift
+PROJECT=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --project)
+            PROJECT="${2:?--project requires a path}"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            ;;
+    esac
+done
+
+# -- Core: apply an action to a set of sources. --
+# Usage: apply <install|uninstall> <target_dir> <label> <strip_ext> <sources...>
+# Sources are pre-expanded by the caller (glob expansion happens at call site).
+
+apply() {
+    local action="$1" target_dir="$2" label="$3" strip_ext="$4"
+    shift 4
+
+    [[ "${action}" == "install" ]] && mkdir -p "${target_dir}"
+
+    for src in "$@"; do
+        [[ -e "${src}" ]] || continue
+        local name
+        name="$(basename "${src}" "${strip_ext}")"
+
+        if [[ "${action}" == "install" ]]; then
+            if [[ -d "${src}" ]]; then
+                ln -sfn "${src}" "${target_dir}/$(basename "${src}")"
+            else
+                ln -sf "${src}" "${target_dir}/"
+            fi
+            echo "  Linked ${label}: ${name}"
+        else
+            rm -rf "${target_dir}/$(basename "${src}")"
+            echo "  Removed ${label}: ${name}"
+        fi
+    done
+}

--- a/scripts/install-cursor.sh
+++ b/scripts/install-cursor.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# Install or uninstall cq for Cursor.
+#
+# Usage:
+#   install-cursor.sh install [--project <path>]
+#   install-cursor.sh uninstall [--project <path>]
+#
+# Without --project, installs globally to ~/.cursor/.
+# With --project, installs into <path>/.cursor/.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PLUGIN_DIR="${REPO_ROOT}/plugins/cq"
+SERVER_DIR="${PLUGIN_DIR}/server"
+
+# -- Dependencies. --
+
+if ! command -v jq &>/dev/null; then
+    echo "Error: jq is required. Install with: brew install jq" >&2
+    exit 1
+fi
+
+# -- Argument parsing. --
+
+usage() {
+    echo "Usage: $(basename "$0") <install|uninstall> [--project <path>]"
+    exit 1
+}
+
+if [[ $# -lt 1 ]]; then
+    usage
+fi
+
+ACTION="$1"
+shift
+PROJECT=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --project)
+            PROJECT="${2:?--project requires a path}"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            ;;
+    esac
+done
+
+if [[ -n "${PROJECT}" ]]; then
+    TARGET="${PROJECT}/.cursor"
+else
+    TARGET="${HOME}/.cursor"
+fi
+
+# -- Core: apply an action to a set of sources. --
+# Usage: apply <install|uninstall> <target_dir> <label> <strip_ext> <sources...>
+
+apply() {
+    local action="$1" target_dir="$2" label="$3" strip_ext="$4"
+    shift 4
+
+    [[ "${action}" == "install" ]] && mkdir -p "${target_dir}"
+
+    for src in "$@"; do
+        [[ -e "${src}" ]] || continue
+        local name
+        name="$(basename "${src}" "${strip_ext}")"
+
+        if [[ "${action}" == "install" ]]; then
+            if [[ -d "${src}" ]]; then
+                ln -sfn "${src}" "${target_dir}/$(basename "${src}")"
+            else
+                ln -sf "${src}" "${target_dir}/"
+            fi
+            echo "  Linked ${label}: ${name}"
+        else
+            rm -rf "${target_dir}/$(basename "${src}")"
+            echo "  Removed ${label}: ${name}"
+        fi
+    done
+}
+
+# -- MCP configuration. --
+# Cursor uses .cursor/mcp.json with a top-level "mcpServers" key.
+
+configure_mcp() {
+    local config_file="${TARGET}/mcp.json"
+    local server_path
+    server_path="$(cd "${SERVER_DIR}" && pwd)"
+
+    local cq_entry
+    cq_entry=$(jq -n \
+        --arg dir "${server_path}" \
+        '{ command: "uv", args: ["run", "--directory", $dir, "cq-mcp-server"] }')
+
+    if [[ -f "${config_file}" ]]; then
+        if jq -e '.mcpServers.cq' "${config_file}" &>/dev/null; then
+            echo "  MCP server already configured in ${config_file}"
+        else
+            local tmp
+            tmp=$(jq --argjson entry "${cq_entry}" '.mcpServers.cq = $entry' "${config_file}")
+            printf '%s\n' "${tmp}" > "${config_file}"
+            echo "  Added cq MCP server to ${config_file}"
+        fi
+    else
+        mkdir -p "$(dirname "${config_file}")"
+        jq -n --argjson entry "${cq_entry}" \
+            '{ mcpServers: { cq: $entry } }' \
+            > "${config_file}"
+        echo "  Created ${config_file} with cq MCP server"
+    fi
+}
+
+remove_mcp() {
+    local config_file="${TARGET}/mcp.json"
+    [[ -f "${config_file}" ]] || return 0
+
+    local tmp
+    tmp=$(jq 'del(.mcpServers.cq) | if .mcpServers == {} then del(.mcpServers) else . end' "${config_file}")
+    printf '%s\n' "${tmp}" > "${config_file}"
+    echo "  Removed cq MCP server from ${config_file}"
+}
+
+# -- Hooks configuration. --
+# Cursor hooks use { "version": 1, "hooks": { "sessionStart": [...] } }.
+# We add a sessionStart hook to pre-sync the MCP server's Python dependencies.
+
+_hook_cmd() {
+    local server_path
+    server_path="$(cd "${SERVER_DIR}" && pwd)"
+    echo "uv sync --directory ${server_path} --quiet"
+}
+
+configure_hooks() {
+    local config_file="${TARGET}/hooks.json"
+    local hook_cmd
+    hook_cmd="$(_hook_cmd)"
+
+    local cq_hook
+    cq_hook=$(jq -n --arg cmd "${hook_cmd}" '{ command: $cmd }')
+
+    if [[ -f "${config_file}" ]]; then
+        if jq -e --arg cmd "${hook_cmd}" '.hooks.sessionStart[]? | select(.command == $cmd)' "${config_file}" &>/dev/null; then
+            echo "  Session start hook already configured in ${config_file}"
+        else
+            local tmp
+            tmp=$(jq --argjson entry "${cq_hook}" '
+                .version //= 1 |
+                .hooks //= {} |
+                .hooks.sessionStart //= [] |
+                .hooks.sessionStart += [$entry]
+            ' "${config_file}")
+            printf '%s\n' "${tmp}" > "${config_file}"
+            echo "  Added session start hook to ${config_file}"
+        fi
+    else
+        mkdir -p "$(dirname "${config_file}")"
+        jq -n --argjson entry "${cq_hook}" '{
+            version: 1,
+            hooks: {
+                sessionStart: [$entry]
+            }
+        }' > "${config_file}"
+        echo "  Created ${config_file} with session start hook"
+    fi
+}
+
+remove_hooks() {
+    local config_file="${TARGET}/hooks.json"
+    [[ -f "${config_file}" ]] || return 0
+
+    local hook_cmd
+    hook_cmd="$(_hook_cmd)"
+
+    local tmp
+    tmp=$(jq --arg cmd "${hook_cmd}" '
+        if .hooks.sessionStart then
+            .hooks.sessionStart |= map(select(.command != $cmd))
+        else . end |
+        if (.hooks.sessionStart // []) == [] then del(.hooks.sessionStart) else . end |
+        if .hooks == {} then del(.hooks) else . end
+    ' "${config_file}")
+    printf '%s\n' "${tmp}" > "${config_file}"
+    echo "  Removed session start hook from ${config_file}"
+}
+
+# -- Rule configuration. --
+# Creates an agent-decided .cursor/rules/cq.mdc rule that directs the
+# agent to load the cq skill. Cursor auto-discovers skills from
+# .cursor/skills/, so this rule provides an additional prompt-level nudge.
+
+CQ_RULE_CONTENT='---
+description: Shared knowledge commons for AI agents. Query before unfamiliar work (APIs, CI/CD, build tools, frameworks). Propose when you discover something non-obvious.
+alwaysApply: false
+---
+
+Before starting any implementation task, load the `cq` skill and follow its Core Protocol.'
+
+configure_rule() {
+    local rules_dir="${TARGET}/rules"
+    local rule_file="${rules_dir}/cq.mdc"
+
+    mkdir -p "${rules_dir}"
+
+    if [[ -f "${rule_file}" ]]; then
+        echo "  Rule already exists at ${rule_file}"
+    else
+        printf '%s\n' "${CQ_RULE_CONTENT}" > "${rule_file}"
+        echo "  Created rule: cq.mdc"
+    fi
+}
+
+remove_rule() {
+    local rule_file="${TARGET}/rules/cq.mdc"
+    if [[ -f "${rule_file}" ]]; then
+        rm -f "${rule_file}"
+        echo "  Removed rule: cq.mdc"
+    fi
+}
+
+# -- Dispatch. --
+
+case "${ACTION}" in
+    install)
+        echo "Installing cq for Cursor (${TARGET})..."
+        apply install "${TARGET}/skills" "skill" "" "${PLUGIN_DIR}"/skills/*/
+        configure_mcp
+        configure_hooks
+        configure_rule
+        echo ""
+        echo "Done. Restart Cursor to pick up the changes."
+        ;;
+    uninstall)
+        echo "Removing cq for Cursor (${TARGET})..."
+        apply uninstall "${TARGET}/skills" "skill" "" "${PLUGIN_DIR}"/skills/*/
+        remove_mcp
+        remove_hooks
+        remove_rule
+        echo ""
+        echo "Done."
+        ;;
+    *)
+        usage
+        ;;
+esac

--- a/scripts/install-cursor.sh
+++ b/scripts/install-cursor.sh
@@ -7,81 +7,15 @@
 #
 # Without --project, installs globally to ~/.cursor/.
 # With --project, installs into <path>/.cursor/.
-set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-PLUGIN_DIR="${REPO_ROOT}/plugins/cq"
-SERVER_DIR="${PLUGIN_DIR}/server"
-
-# -- Dependencies. --
-
-if ! command -v jq &>/dev/null; then
-    echo "Error: jq is required. Install with: brew install jq" >&2
-    exit 1
-fi
-
-# -- Argument parsing. --
-
-usage() {
-    echo "Usage: $(basename "$0") <install|uninstall> [--project <path>]"
-    exit 1
-}
-
-if [[ $# -lt 1 ]]; then
-    usage
-fi
-
-ACTION="$1"
-shift
-PROJECT=""
-
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --project)
-            PROJECT="${2:?--project requires a path}"
-            shift 2
-            ;;
-        *)
-            echo "Unknown option: $1" >&2
-            usage
-            ;;
-    esac
-done
+# shellcheck source=_install-common.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_install-common.sh" "$@"
 
 if [[ -n "${PROJECT}" ]]; then
     TARGET="${PROJECT}/.cursor"
 else
     TARGET="${HOME}/.cursor"
 fi
-
-# -- Core: apply an action to a set of sources. --
-# Usage: apply <install|uninstall> <target_dir> <label> <strip_ext> <sources...>
-
-apply() {
-    local action="$1" target_dir="$2" label="$3" strip_ext="$4"
-    shift 4
-
-    [[ "${action}" == "install" ]] && mkdir -p "${target_dir}"
-
-    for src in "$@"; do
-        [[ -e "${src}" ]] || continue
-        local name
-        name="$(basename "${src}" "${strip_ext}")"
-
-        if [[ "${action}" == "install" ]]; then
-            if [[ -d "${src}" ]]; then
-                ln -sfn "${src}" "${target_dir}/$(basename "${src}")"
-            else
-                ln -sf "${src}" "${target_dir}/"
-            fi
-            echo "  Linked ${label}: ${name}"
-        else
-            rm -rf "${target_dir}/$(basename "${src}")"
-            echo "  Removed ${label}: ${name}"
-        fi
-    done
-}
 
 # -- MCP configuration. --
 # Cursor uses .cursor/mcp.json with a top-level "mcpServers" key.

--- a/scripts/install-cursor.sh
+++ b/scripts/install-cursor.sh
@@ -20,6 +20,10 @@ fi
 # -- MCP configuration. --
 # Cursor uses .cursor/mcp.json with a top-level "mcpServers" key.
 
+_shell_quote() {
+    printf '%q' "$1"
+}
+
 configure_mcp() {
     local config_file="${TARGET}/mcp.json"
     local server_path
@@ -27,8 +31,9 @@ configure_mcp() {
 
     local cq_entry
     cq_entry=$(jq -n \
+        --arg uv "${UV_BIN}" \
         --arg dir "${server_path}" \
-        '{ command: "uv", args: ["run", "--directory", $dir, "cq-mcp-server"] }')
+        '{ command: $uv, args: ["run", "--directory", $dir, "cq-mcp-server"] }')
 
     if [[ -f "${config_file}" ]]; then
         if jq -e '.mcpServers.cq' "${config_file}" &>/dev/null; then
@@ -59,66 +64,101 @@ remove_mcp() {
 }
 
 # -- Hooks configuration. --
-# Cursor hooks use { "version": 1, "hooks": { "sessionStart": [...] } }.
-# We add a sessionStart hook to pre-sync the MCP server's Python dependencies.
+# Cursor hooks use { "version": 1, "hooks": { ... } }.
+# We install a sessionStart hook that syncs the MCP server environment and
+# sets session-scoped state, a postToolUseFailure hook that records the last
+# failed tool, a postToolUse hook that clears stale failures after recovery,
+# and a stop hook that auto-submits a cq follow-up when the agent loop ends
+# immediately after a tool failure.
+
+_hook_script() {
+    local hook_dir
+    hook_dir="$(cd "${PLUGIN_DIR}/hooks/cursor" && pwd)"
+    printf '%s' "${hook_dir}/cq_cursor_hook.py"
+}
 
 _hook_cmd() {
+    local mode="$1"
+    local server_path script_path
+    server_path="$(cd "${SERVER_DIR}" && pwd)"
+    script_path="$(_hook_script)"
+    printf '%s --mode %s' \
+        "$(_shell_quote "${script_path}")" \
+        "$(_shell_quote "${mode}")"
+    if [[ "${mode}" == "session-start" ]]; then
+        printf ' --server-dir %s --uv-bin %s' \
+            "$(_shell_quote "${server_path}")" \
+            "$(_shell_quote "${UV_BIN}")"
+    fi
+}
+
+_legacy_session_start_cmd() {
     local server_path
     server_path="$(cd "${SERVER_DIR}" && pwd)"
-    echo "uv sync --directory ${server_path} --quiet"
+    printf 'uv sync --directory %s --quiet' "${server_path}"
+}
+
+_ensure_hook() {
+    local config_file="$1" hook_name="$2" command="$3" label="$4"
+    local hook_entry
+    hook_entry=$(jq -n --arg cmd "${command}" '{ command: $cmd }')
+
+    if jq -e --arg hook "${hook_name}" --arg cmd "${command}" \
+        '.hooks[$hook][]? | select(.command == $cmd)' "${config_file}" &>/dev/null; then
+        echo "  ${label} already configured in ${config_file}"
+        return 0
+    fi
+
+    local tmp
+    tmp=$(jq --arg hook "${hook_name}" --argjson entry "${hook_entry}" '
+        .version //= 1 |
+        .hooks //= {} |
+        .hooks[$hook] //= [] |
+        .hooks[$hook] += [$entry]
+    ' "${config_file}")
+    printf '%s\n' "${tmp}" > "${config_file}"
+    echo "  Added ${label} to ${config_file}"
+}
+
+_remove_hook() {
+    local config_file="$1" hook_name="$2" command="$3" label="$4"
+    local tmp
+    tmp=$(jq --arg hook "${hook_name}" --arg cmd "${command}" '
+        if .hooks[$hook] then
+            .hooks[$hook] |= map(select(.command != $cmd))
+        else . end |
+        if (.hooks[$hook] // []) == [] then del(.hooks[$hook]) else . end |
+        if .hooks == {} then del(.hooks) else . end
+    ' "${config_file}")
+    printf '%s\n' "${tmp}" > "${config_file}"
+    echo "  Removed ${label} from ${config_file}"
 }
 
 configure_hooks() {
     local config_file="${TARGET}/hooks.json"
-    local hook_cmd
-    hook_cmd="$(_hook_cmd)"
-
-    local cq_hook
-    cq_hook=$(jq -n --arg cmd "${hook_cmd}" '{ command: $cmd }')
-
-    if [[ -f "${config_file}" ]]; then
-        if jq -e --arg cmd "${hook_cmd}" '.hooks.sessionStart[]? | select(.command == $cmd)' "${config_file}" &>/dev/null; then
-            echo "  Session start hook already configured in ${config_file}"
-        else
-            local tmp
-            tmp=$(jq --argjson entry "${cq_hook}" '
-                .version //= 1 |
-                .hooks //= {} |
-                .hooks.sessionStart //= [] |
-                .hooks.sessionStart += [$entry]
-            ' "${config_file}")
-            printf '%s\n' "${tmp}" > "${config_file}"
-            echo "  Added session start hook to ${config_file}"
-        fi
-    else
+    if [[ ! -f "${config_file}" ]]; then
         mkdir -p "$(dirname "${config_file}")"
-        jq -n --argjson entry "${cq_hook}" '{
-            version: 1,
-            hooks: {
-                sessionStart: [$entry]
-            }
-        }' > "${config_file}"
-        echo "  Created ${config_file} with session start hook"
+        jq -n '{ version: 1, hooks: {} }' > "${config_file}"
+        echo "  Created ${config_file}"
     fi
+
+    _remove_hook "${config_file}" "sessionStart" "$(_legacy_session_start_cmd)" "legacy session start hook"
+
+    _ensure_hook "${config_file}" "sessionStart" "$(_hook_cmd session-start)" "session start hook"
+    _ensure_hook "${config_file}" "postToolUseFailure" "$(_hook_cmd post-tool-use-failure)" "postToolUseFailure hook"
+    _ensure_hook "${config_file}" "postToolUse" "$(_hook_cmd post-tool-use)" "postToolUse hook"
+    _ensure_hook "${config_file}" "stop" "$(_hook_cmd stop)" "stop hook"
 }
 
 remove_hooks() {
     local config_file="${TARGET}/hooks.json"
     [[ -f "${config_file}" ]] || return 0
 
-    local hook_cmd
-    hook_cmd="$(_hook_cmd)"
-
-    local tmp
-    tmp=$(jq --arg cmd "${hook_cmd}" '
-        if .hooks.sessionStart then
-            .hooks.sessionStart |= map(select(.command != $cmd))
-        else . end |
-        if (.hooks.sessionStart // []) == [] then del(.hooks.sessionStart) else . end |
-        if .hooks == {} then del(.hooks) else . end
-    ' "${config_file}")
-    printf '%s\n' "${tmp}" > "${config_file}"
-    echo "  Removed session start hook from ${config_file}"
+    _remove_hook "${config_file}" "sessionStart" "$(_legacy_session_start_cmd)" "legacy session start hook"
+    _remove_hook "${config_file}" "sessionStart" "$(_hook_cmd session-start)" "session start hook"
+    _remove_hook "${config_file}" "postToolUseFailure" "$(_hook_cmd post-tool-use-failure)" "postToolUseFailure hook"
+    _remove_hook "${config_file}" "postToolUse" "$(_hook_cmd post-tool-use)" "postToolUse hook"
+    _remove_hook "${config_file}" "stop" "$(_hook_cmd stop)" "stop hook"
 }
 
 # -- Rule configuration. --

--- a/scripts/install-opencode.sh
+++ b/scripts/install-opencode.sh
@@ -7,82 +7,15 @@
 #
 # Without --project, installs globally to ~/.config/opencode/.
 # With --project, installs into <path>/.opencode/.
-set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-PLUGIN_DIR="${REPO_ROOT}/plugins/cq"
-SERVER_DIR="${PLUGIN_DIR}/server"
-
-# -- Dependencies. --
-
-if ! command -v jq &>/dev/null; then
-    echo "Error: jq is required. Install with: brew install jq" >&2
-    exit 1
-fi
-
-# -- Argument parsing. --
-
-usage() {
-    echo "Usage: $(basename "$0") <install|uninstall> [--project <path>]"
-    exit 1
-}
-
-if [[ $# -lt 1 ]]; then
-    usage
-fi
-
-ACTION="$1"
-shift
-PROJECT=""
-
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --project)
-            PROJECT="${2:?--project requires a path}"
-            shift 2
-            ;;
-        *)
-            echo "Unknown option: $1" >&2
-            usage
-            ;;
-    esac
-done
+# shellcheck source=_install-common.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_install-common.sh" "$@"
 
 if [[ -n "${PROJECT}" ]]; then
     TARGET="${PROJECT}/.opencode"
 else
     TARGET="${HOME}/.config/opencode"
 fi
-
-# -- Core: apply an action to a set of sources. --
-# Usage: apply <install|uninstall> <target_dir> <label> <strip_ext> <sources...>
-# Sources are pre-expanded by the caller (glob expansion happens at call site).
-
-apply() {
-    local action="$1" target_dir="$2" label="$3" strip_ext="$4"
-    shift 4
-
-    [[ "${action}" == "install" ]] && mkdir -p "${target_dir}"
-
-    for src in "$@"; do
-        [[ -e "${src}" ]] || continue
-        local name
-        name="$(basename "${src}" "${strip_ext}")"
-
-        if [[ "${action}" == "install" ]]; then
-            if [[ -d "${src}" ]]; then
-                ln -sfn "${src}" "${target_dir}/$(basename "${src}")"
-            else
-                ln -sf "${src}" "${target_dir}/"
-            fi
-            echo "  Linked ${label}: ${name}"
-        else
-            rm -rf "${target_dir}/$(basename "${src}")"
-            echo "  Removed ${label}: ${name}"
-        fi
-    done
-}
 
 # -- Generate OpenCode command files from Claude Code command files. --
 # Strips the `name:` frontmatter field and adds `agent: build`.


### PR DESCRIPTION
##  Summary

This branch adds Cursor support for cq while keeping the core architecture and agent behavior aligned with the existing plugin model. It introduces Cursor installation and hook wiring, factors shared install logic into common helpers, and updates the docs to describe the architecture in a host-agnostic way while explicitly calling out where Cursor and Claude Code differ.

## Test Plan

- Install cq into Cursor and verify the MCP server, skill, rule, and hooks are wired correctly.
- Verify failed tool calls in Cursor record failure context and produce the intended cq follow-up behavior.
- Confirm OpenCode install flow still works after the shared installer refactor.
- Review docs for consistency across README.md, DEVELOPMENT.md, and docs/architecture.md.