### PR TITLE
Add multi-value language/framework query tests to Go SDK

### DIFF
--- a/sdk/go/remote_test.go
+++ b/sdk/go/remote_test.go
@@ -173,27 +173,46 @@ func TestRemoteFlagOmitsEmptyFields(t *testing.T) {
 
 func TestRemoteQuerySendsPluralParamNames(t *testing.T) {
 	t.Parallel()
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Verify plural param names.
-		require.NotEmpty(t, r.URL.Query()["domains"], "should send 'domains' not 'domain'")
-		require.Empty(t, r.URL.Query()["domain"], "should not send singular 'domain'")
 
-		if langs := r.URL.Query()["languages"]; len(langs) > 0 {
-			require.Equal(t, []string{"go"}, langs)
-		}
-		if fws := r.URL.Query()["frameworks"]; len(fws) > 0 {
-			require.Equal(t, []string{"grpc"}, fws)
-		}
+	t.Run("single values", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.NotEmpty(t, r.URL.Query()["domains"], "should send 'domains' not 'domain'")
+			require.Empty(t, r.URL.Query()["domain"], "should not send singular 'domain'")
 
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]map[string]any{})
-	}))
-	defer srv.Close()
+			require.Equal(t, []string{"go"}, r.URL.Query()["languages"])
+			require.Equal(t, []string{"grpc"}, r.URL.Query()["frameworks"])
 
-	rc := newRemoteClient(srv.URL, "", 5*time.Second)
-	rc.query(context.Background(), QueryParams{
-		Domains:    []string{"api"},
-		Languages:  []string{"go"},
-		Frameworks: []string{"grpc"},
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+		}))
+		defer srv.Close()
+
+		rc := newRemoteClient(srv.URL, "", 5*time.Second)
+		rc.query(context.Background(), QueryParams{
+			Domains:    []string{"api"},
+			Languages:  []string{"go"},
+			Frameworks: []string{"grpc"},
+		})
+	})
+
+	t.Run("multiple values", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, []string{"api", "testing"}, r.URL.Query()["domains"])
+			require.Equal(t, []string{"python", "go"}, r.URL.Query()["languages"])
+			require.Equal(t, []string{"grpc", "http"}, r.URL.Query()["frameworks"])
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+		}))
+		defer srv.Close()
+
+		rc := newRemoteClient(srv.URL, "", 5*time.Second)
+		rc.query(context.Background(), QueryParams{
+			Domains:    []string{"api", "testing"},
+			Languages:  []string{"python", "go"},
+			Frameworks: []string{"grpc", "http"},
+		})
 	})
 }

--- a/sdk/go/store_test.go
+++ b/sdk/go/store_test.go
@@ -508,6 +508,56 @@ func TestQuery(t *testing.T) {
 		require.Equal(t, kuGo.ID, results.KUs[0].ID)
 	})
 
+	t.Run("multi-language query boosts any overlap", func(t *testing.T) {
+		t.Parallel()
+		s := newTestStore(t)
+
+		kuMatch := newFakeKU(t, []string{"api"})
+		kuMatch.Context = Context{Languages: []string{"python"}}
+		kuMatch.Evidence.Confidence = 0.8
+		require.NoError(t, s.insert(kuMatch))
+
+		kuNoMatch := newFakeKU(t, []string{"api"})
+		kuNoMatch.Context = Context{Languages: []string{"rust"}}
+		kuNoMatch.Evidence.Confidence = 0.8
+		require.NoError(t, s.insert(kuNoMatch))
+
+		// Querying with multiple languages; "python" overlaps with kuMatch.
+		results, err := s.query(
+			withDomain("api"),
+			withLanguage("python"), withLanguage("go"),
+			withLimit(10),
+		)
+		require.NoError(t, err)
+		require.Len(t, results.KUs, 2)
+		require.Equal(t, kuMatch.ID, results.KUs[0].ID, "unit with overlapping language should rank first")
+	})
+
+	t.Run("multi-framework query boosts any overlap", func(t *testing.T) {
+		t.Parallel()
+		s := newTestStore(t)
+
+		kuMatch := newFakeKU(t, []string{"api"})
+		kuMatch.Context = Context{Frameworks: []string{"grpc"}}
+		kuMatch.Evidence.Confidence = 0.8
+		require.NoError(t, s.insert(kuMatch))
+
+		kuNoMatch := newFakeKU(t, []string{"api"})
+		kuNoMatch.Context = Context{Frameworks: []string{"django"}}
+		kuNoMatch.Evidence.Confidence = 0.8
+		require.NoError(t, s.insert(kuNoMatch))
+
+		// Querying with multiple frameworks; "grpc" overlaps with kuMatch.
+		results, err := s.query(
+			withDomain("api"),
+			withFramework("grpc"), withFramework("http"),
+			withLimit(10),
+		)
+		require.NoError(t, err)
+		require.Len(t, results.KUs, 2)
+		require.Equal(t, kuMatch.ID, results.KUs[0].ID, "unit with overlapping framework should rank first")
+	})
+
 	t.Run("higher confidence ranks higher", func(t *testing.T) {
 		t.Parallel()
 		s := newTestStore(t)


### PR DESCRIPTION
## Summary
- Add store-layer tests for multi-value language and framework query
  boosting, verifying that anyMatch() correctly ranks units with any
  overlap higher than those with none.
- Restructure TestRemoteQuerySendsPluralParamNames into subtests and add
  a "multiple values" case that verifies all three plural params encode
  correctly with more than one value.

Fixes #197

## Test plan
- [x] `make test` passes (Go SDK, Python SDK, CLI, server, team-api)
- [x] `make lint` passes for Go components
- [x] New tests fail when anyMatch is stubbed to ignore multi-value
  queries, confirming they exercise the intended code path