### PR TITLE
Add configurable HTTP timeout to Python SDK Client (#173)

### DIFF
--- a/sdk/python/src/cq/client.py
+++ b/sdk/python/src/cq/client.py
@@ -51,6 +51,7 @@ class Client:
         self,
         addr: str | None = None,
         local_db_path: Path | None = None,
+        timeout: float = _DEFAULT_TIMEOUT,
     ) -> None:
         """Initialize the client.
 
@@ -59,6 +60,7 @@ class Client:
                 env var if not provided. None = local-only mode.
             local_db_path: Local SQLite path. Reads from CQ_LOCAL_DB_PATH
                 env var if not provided. Defaults to $XDG_DATA_HOME/cq/local.db.
+            timeout: HTTP request timeout in seconds. Defaults to 5.0.
         """
         self._addr = addr or os.environ.get("CQ_ADDR")
         db_path = local_db_path or _db_path_from_env()
@@ -69,7 +71,7 @@ class Client:
             headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
             self._http = httpx.Client(
                 base_url=self._addr,
-                timeout=_DEFAULT_TIMEOUT,
+                timeout=timeout,
                 headers=headers,
             )
 

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -253,6 +253,23 @@ class TestRemoteConfig:
             assert c._store.db_path == db
             c.close()
 
+    def test_default_timeout_used_when_not_specified(self, tmp_path: Path):
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        assert c._http is not None
+        assert c._http.timeout == httpx.Timeout(5.0)
+        c.close()
+
+    def test_custom_timeout_forwarded_to_http_client(self, tmp_path: Path):
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db", timeout=15.0)
+        assert c._http is not None
+        assert c._http.timeout == httpx.Timeout(15.0)
+        c.close()
+
+    def test_timeout_without_remote_addr(self, tmp_path: Path):
+        c = Client(local_db_path=tmp_path / "test.db", timeout=10.0)
+        assert c._http is None
+        c.close()
+
 
 class TestRemoteIntegration:
     def test_remote_query_merges_with_local(self, tmp_path: Path, httpx_mock):


### PR DESCRIPTION
## Summary

- Add `timeout` parameter to `Client.__init__()` for parity with Go SDK's `WithTimeout()`.
- Default remains `_DEFAULT_TIMEOUT` (5.0s); callers can override with any float value.
- Three new tests covering default, custom, and local-only scenarios.

Closes #173

## Test plan

- [x] Existing test suite passes (216 SDK + 95 server tests).
- [x] New tests verify default timeout, custom timeout forwarding, and local-only mode.
- [x] Linting passes (`make lint`).