### PR TITLE
Rename domain to domains in server API endpoints (#177)

### DIFF
--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -21,13 +21,13 @@ from .knowledge_unit import (
 )
 from .review import router as review_router
 from .scoring import apply_confirmation, apply_flag
-from .store import TeamStore, normalise_domains
+from .store import TeamStore, normalize_domains
 
 
 class ProposeRequest(BaseModel):
     """Request body for proposing a new knowledge unit."""
 
-    domain: list[str] = Field(min_length=1)
+    domains: list[str] = Field(min_length=1)
     insight: Insight
     context: Context = Field(default_factory=Context)
     created_by: str = ""
@@ -83,25 +83,25 @@ def health() -> dict[str, str]:
 
 @app.get("/query")
 def query_units(
-    domain: Annotated[list[str], Query()],
+    domains: Annotated[list[str], Query()],
     language: Annotated[str | None, Query()] = None,
     framework: Annotated[str | None, Query()] = None,
     limit: Annotated[int, Query(gt=0)] = 5,
 ) -> list[KnowledgeUnit]:
     """Search knowledge units by domain tags with relevance ranking."""
     store = _get_store()
-    return store.query(domain, language=language, framework=framework, limit=limit)
+    return store.query(domains, language=language, framework=framework, limit=limit)
 
 
 @app.post("/propose", status_code=201)
 def propose_unit(request: ProposeRequest) -> KnowledgeUnit:
     """Submit a new knowledge unit to the team store."""
     store = _get_store()
-    domains = normalise_domains(request.domain)
-    if not domains:
+    normalized = normalize_domains(request.domains)
+    if not normalized:
         raise HTTPException(status_code=422, detail="At least one non-empty domain is required")
     unit = create_knowledge_unit(
-        domain=domains,
+        domains=normalized,
         insight=request.insight,
         context=request.context,
         tier=Tier.TEAM,

--- a/server/backend/src/cq_server/knowledge_unit.py
+++ b/server/backend/src/cq_server/knowledge_unit.py
@@ -80,7 +80,7 @@ class KnowledgeUnit(BaseModel):
 
     id: str
     version: int = 1
-    domain: list[str] = Field(min_length=1)
+    domains: list[str] = Field(min_length=1)
     insight: Insight
     context: Context = Field(default_factory=Context)
     evidence: Evidence = Field(default_factory=Evidence)
@@ -97,7 +97,7 @@ def _generate_ku_id() -> str:
 
 def create_knowledge_unit(
     *,
-    domain: list[str],
+    domains: list[str],
     insight: Insight,
     context: Context | None = None,
     tier: Tier = Tier.LOCAL,
@@ -106,7 +106,7 @@ def create_knowledge_unit(
     """Create a new knowledge unit with an auto-generated ID."""
     return KnowledgeUnit(
         id=_generate_ku_id(),
-        domain=domain,
+        domains=domains,
         insight=insight,
         context=context or Context(),
         tier=tier,

--- a/server/backend/src/cq_server/scoring.py
+++ b/server/backend/src/cq_server/scoring.py
@@ -55,7 +55,7 @@ def calculate_relevance(
     framework_weight = 0.15
 
     # Domain overlap scored by Jaccard similarity.
-    unit_domains = set(unit.domain)
+    unit_domains = set(unit.domains)
     query_domain_set = set(query_domains)
     if unit_domains or query_domain_set:
         domain_score = len(unit_domains & query_domain_set) / len(unit_domains | query_domain_set)

--- a/server/backend/src/cq_server/store.py
+++ b/server/backend/src/cq_server/store.py
@@ -36,7 +36,7 @@ CREATE INDEX IF NOT EXISTS idx_domains_domain
 """
 
 
-def normalise_domains(domains: list[str]) -> list[str]:
+def normalize_domains(domains: list[str]) -> list[str]:
     """Lowercase, strip whitespace, drop empties, and deduplicate domain tags."""
     return list(dict.fromkeys(d.strip().lower() for d in domains if d.strip()))
 
@@ -116,13 +116,13 @@ class TeamStore:
 
         Raises:
             sqlite3.IntegrityError: If a unit with the same ID already exists.
-            ValueError: If domain normalisation results in no valid domains.
+            ValueError: If domain normalization results in no valid domains.
         """
         self._check_open()
-        domains = normalise_domains(unit.domain)
+        domains = normalize_domains(unit.domains)
         if not domains:
             raise ValueError("At least one non-empty domain is required")
-        unit = unit.model_copy(update={"domain": domains})
+        unit = unit.model_copy(update={"domains": domains})
         data = unit.model_dump_json()
         created_at = (
             unit.evidence.first_observed.isoformat() if unit.evidence.first_observed else datetime.now(UTC).isoformat()
@@ -229,13 +229,13 @@ class TeamStore:
 
         Raises:
             KeyError: If no unit with the given ID exists.
-            ValueError: If domain normalisation results in no valid domains.
+            ValueError: If domain normalization results in no valid domains.
         """
         self._check_open()
-        domains = normalise_domains(unit.domain)
+        domains = normalize_domains(unit.domains)
         if not domains:
             raise ValueError("At least one non-empty domain is required")
-        unit = unit.model_copy(update={"domain": domains})
+        unit = unit.model_copy(update={"domains": domains})
         data = unit.model_dump_json()
         with self._lock, self._conn:
             cursor = self._conn.execute(
@@ -283,11 +283,11 @@ class TeamStore:
         if not domains:
             return []
 
-        normalised = normalise_domains(domains)
-        if not normalised:
+        normalized = normalize_domains(domains)
+        if not normalized:
             return []
         # Safe: placeholders is only '?' characters, never user input.
-        placeholders = ",".join("?" for _ in normalised)
+        placeholders = ",".join("?" for _ in normalized)
         sql = f"""
             SELECT ku.data
             FROM knowledge_units ku
@@ -299,7 +299,7 @@ class TeamStore:
             )
         """
         with self._lock:
-            rows = self._conn.execute(sql, normalised).fetchall()
+            rows = self._conn.execute(sql, normalized).fetchall()
 
         # PoC: all filtering and scoring is in-memory after deserialization.
         # For larger stores, push coarse filters into SQL.
@@ -309,7 +309,7 @@ class TeamStore:
         for unit in units:
             relevance = calculate_relevance(
                 unit,
-                normalised,
+                normalized,
                 query_language=language,
                 query_framework=framework,
             )
@@ -415,11 +415,11 @@ class TeamStore:
             params.append(status)
 
         if domain:
-            normalised = normalise_domains([domain])
-            if not normalised:
+            normalized = normalize_domains([domain])
+            if not normalized:
                 return []
             conditions.append("ku.id IN (  SELECT DISTINCT unit_id FROM knowledge_unit_domains WHERE domain = ?)")
-            params.append(normalised[0])
+            params.append(normalized[0])
 
         has_confidence_filter = confidence_min is not None or confidence_max is not None
         where = f"WHERE {' AND '.join(conditions)}" if conditions else ""

--- a/server/backend/tests/test_app.py
+++ b/server/backend/tests/test_app.py
@@ -20,7 +20,7 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
 
 def _propose_payload(**overrides: Any) -> dict[str, Any]:
     defaults: dict[str, Any] = {
-        "domain": ["databases", "performance"],
+        "domains": ["databases", "performance"],
         "insight": {
             "summary": "Use connection pooling",
             "detail": "Database connections are expensive to create.",
@@ -51,7 +51,7 @@ class TestPropose:
         assert resp.status_code == 201
         body = resp.json()
         assert body["id"].startswith("ku_")
-        assert body["domain"] == ["databases", "performance"]
+        assert body["domains"] == ["databases", "performance"]
         assert body["insight"]["summary"] == "Use connection pooling"
         assert body["evidence"]["confidence"] == 0.5
 
@@ -65,21 +65,21 @@ class TestPropose:
         assert "python" in body["context"]["languages"]
         assert "fastapi" in body["context"]["frameworks"]
 
-    def test_propose_with_empty_domain_rejected(self, client: TestClient) -> None:
-        payload = _propose_payload(domain=[])
+    def test_propose_with_empty_domains_rejected(self, client: TestClient) -> None:
+        payload = _propose_payload(domains=[])
         resp = client.post("/propose", json=payload)
         assert resp.status_code == 422
 
     def test_propose_with_whitespace_only_domains_rejected(self, client: TestClient) -> None:
-        payload = _propose_payload(domain=["  ", ""])
+        payload = _propose_payload(domains=["  ", ""])
         resp = client.post("/propose", json=payload)
         assert resp.status_code == 422
 
-    def test_propose_normalises_domains(self, client: TestClient) -> None:
-        payload = _propose_payload(domain=["API", " Databases "])
+    def test_propose_normalizes_domains(self, client: TestClient) -> None:
+        payload = _propose_payload(domains=["API", " Databases "])
         resp = client.post("/propose", json=payload)
         assert resp.status_code == 201
-        assert resp.json()["domain"] == ["api", "databases"]
+        assert resp.json()["domains"] == ["api", "databases"]
 
 
 class TestQuery:
@@ -91,31 +91,31 @@ class TestQuery:
         return body
 
     def test_query_returns_matching_units(self, client: TestClient) -> None:
-        self._insert_unit(client, domain=["databases"])
-        resp = client.get("/query", params={"domain": ["databases"]})
+        self._insert_unit(client, domains=["databases"])
+        resp = client.get("/query", params={"domains": ["databases"]})
         assert resp.status_code == 200
         results = resp.json()
         assert len(results) == 1
-        assert results[0]["domain"] == ["databases"]
+        assert results[0]["domains"] == ["databases"]
 
     def test_query_returns_empty_for_no_match(self, client: TestClient) -> None:
-        self._insert_unit(client, domain=["databases"])
-        resp = client.get("/query", params={"domain": ["networking"]})
+        self._insert_unit(client, domains=["databases"])
+        resp = client.get("/query", params={"domains": ["networking"]})
         assert resp.status_code == 200
         assert resp.json() == []
 
     def test_query_boosts_matching_language(self, client: TestClient) -> None:
         self._insert_unit(
             client,
-            domain=["web"],
+            domains=["web"],
             context={"languages": ["python"], "frameworks": []},
         )
         self._insert_unit(
             client,
-            domain=["web"],
+            domains=["web"],
             context={"languages": ["go"], "frameworks": []},
         )
-        resp = client.get("/query", params={"domain": ["web"], "language": "python"})
+        resp = client.get("/query", params={"domains": ["web"], "language": "python"})
         assert resp.status_code == 200
         results = resp.json()
         assert len(results) == 2
@@ -123,13 +123,13 @@ class TestQuery:
 
     def test_query_respects_limit(self, client: TestClient) -> None:
         for _ in range(3):
-            self._insert_unit(client, domain=["api"])
-        resp = client.get("/query", params={"domain": ["api"], "limit": 2})
+            self._insert_unit(client, domains=["api"])
+        resp = client.get("/query", params={"domains": ["api"], "limit": 2})
         assert resp.status_code == 200
         assert len(resp.json()) == 2
 
     def test_query_rejects_zero_limit(self, client: TestClient) -> None:
-        resp = client.get("/query", params={"domain": ["api"], "limit": 0})
+        resp = client.get("/query", params={"domains": ["api"], "limit": 0})
         assert resp.status_code == 422
 
 
@@ -190,8 +190,8 @@ class TestStats:
     def test_stats_after_inserts(self, client: TestClient) -> None:
         from cq_server.app import _get_store
 
-        r1 = client.post("/propose", json=_propose_payload(domain=["api", "auth"]))
-        r2 = client.post("/propose", json=_propose_payload(domain=["api", "payments"]))
+        r1 = client.post("/propose", json=_propose_payload(domains=["api", "auth"]))
+        r2 = client.post("/propose", json=_propose_payload(domains=["api", "payments"]))
         store = _get_store()
         store.set_review_status(r1.json()["id"], "approved", "tester")
         store.set_review_status(r2.json()["id"], "approved", "tester")
@@ -227,12 +227,12 @@ class TestReviewLifecycleEndToEnd:
         headers = {"Authorization": f"Bearer {token}"}
 
         # Agent proposes a KU.
-        propose_resp = client.post("/propose", json=_propose_payload(domain=["e2e-test"]))
+        propose_resp = client.post("/propose", json=_propose_payload(domains=["e2e-test"]))
         assert propose_resp.status_code == 201
         unit_id = propose_resp.json()["id"]
 
         # KU is not queryable yet (pending).
-        query_resp = client.get("/query", params={"domain": ["e2e-test"]})
+        query_resp = client.get("/query", params={"domains": ["e2e-test"]})
         assert len(query_resp.json()) == 0
 
         # KU appears in review queue.
@@ -245,7 +245,7 @@ class TestReviewLifecycleEndToEnd:
         assert approve_resp.json()["status"] == "approved"
 
         # KU is now queryable.
-        query_resp = client.get("/query", params={"domain": ["e2e-test"]})
+        query_resp = client.get("/query", params={"domains": ["e2e-test"]})
         assert len(query_resp.json()) == 1
 
         # Queue is empty.
@@ -269,7 +269,7 @@ class TestEndToEnd:
     def test_propose_confirm_flag_lifecycle(self, client: TestClient) -> None:
         # Propose a unit.
         payload = _propose_payload(
-            domain=["api", "payments"],
+            domains=["api", "payments"],
             context={"languages": ["python"], "frameworks": ["fastapi"]},
         )
         created = client.post("/propose", json=payload)
@@ -282,7 +282,7 @@ class TestEndToEnd:
         # Query returns the unit.
         resp = client.get(
             "/query",
-            params={"domain": ["api", "payments"], "language": "python"},
+            params={"domains": ["api", "payments"], "language": "python"},
         )
         assert len(resp.json()) == 1
         assert resp.json()[0]["evidence"]["confidence"] == 0.5
@@ -291,14 +291,14 @@ class TestEndToEnd:
         resp = client.post(f"/confirm/{unit_id}")
         assert resp.status_code == 200
 
-        resp = client.get("/query", params={"domain": ["api", "payments"]})
+        resp = client.get("/query", params={"domains": ["api", "payments"]})
         assert resp.json()[0]["evidence"]["confidence"] == pytest.approx(0.6)
 
         # Flag reduces confidence.
         resp = client.post(f"/flag/{unit_id}", json={"reason": "stale"})
         assert resp.status_code == 200
 
-        resp = client.get("/query", params={"domain": ["api", "payments"]})
+        resp = client.get("/query", params={"domains": ["api", "payments"]})
         result = resp.json()[0]
         assert result["evidence"]["confidence"] == pytest.approx(0.45)
         assert len(result["flags"]) == 1

--- a/server/backend/tests/test_review.py
+++ b/server/backend/tests/test_review.py
@@ -38,7 +38,7 @@ def _auth_header(token: str) -> dict[str, str]:
 
 def _propose(client: TestClient, **overrides: Any) -> dict[str, Any]:
     defaults: dict[str, Any] = {
-        "domain": ["api", "testing"],
+        "domains": ["api", "testing"],
         "insight": {
             "summary": "Test insight",
             "detail": "Detail here.",
@@ -96,9 +96,9 @@ class TestApprove:
 
     def test_approved_unit_appears_in_query(self, client: TestClient) -> None:
         token = _login(client)
-        unit = _propose(client, domain=["searchable"])
+        unit = _propose(client, domains=["searchable"])
         client.post(f"/review/{unit['id']}/approve", headers=_auth_header(token))
-        resp = client.get("/query", params={"domain": ["searchable"]})
+        resp = client.get("/query", params={"domains": ["searchable"]})
         assert len(resp.json()) == 1
 
 
@@ -113,22 +113,22 @@ class TestReject:
 
     def test_rejected_unit_not_in_query(self, client: TestClient) -> None:
         token = _login(client)
-        unit = _propose(client, domain=["hidden"])
+        unit = _propose(client, domains=["hidden"])
         client.post(f"/review/{unit['id']}/reject", headers=_auth_header(token))
-        resp = client.get("/query", params={"domain": ["hidden"]})
+        resp = client.get("/query", params={"domains": ["hidden"]})
         assert len(resp.json()) == 0
 
 
 class TestListUnits:
     def test_filter_by_domain(self, client: TestClient) -> None:
         token = _login(client)
-        _propose(client, domain=["python"])
-        _propose(client, domain=["rust"])
+        _propose(client, domains=["python"])
+        _propose(client, domains=["rust"])
         resp = client.get("/review/units", params={"domain": "python"}, headers=_auth_header(token))
         assert resp.status_code == 200
         items = resp.json()
         assert len(items) == 1
-        assert "python" in items[0]["knowledge_unit"]["domain"]
+        assert "python" in items[0]["knowledge_unit"]["domains"]
 
     def test_filter_by_confidence_range(self, client: TestClient) -> None:
         """Default confidence from propose is 0.5; filter to include/exclude it."""
@@ -154,9 +154,9 @@ class TestListUnits:
 
     def test_includes_all_statuses(self, client: TestClient) -> None:
         token = _login(client)
-        u1 = _propose(client, domain=["mixed"])
-        u2 = _propose(client, domain=["mixed"])
-        _propose(client, domain=["mixed"])
+        u1 = _propose(client, domains=["mixed"])
+        u2 = _propose(client, domains=["mixed"])
+        _propose(client, domains=["mixed"])
         client.post(f"/review/{u1['id']}/approve", headers=_auth_header(token))
         client.post(f"/review/{u2['id']}/reject", headers=_auth_header(token))
         resp = client.get("/review/units", params={"domain": "mixed"}, headers=_auth_header(token))
@@ -168,8 +168,8 @@ class TestListUnits:
 
     def test_filter_by_status(self, client: TestClient) -> None:
         token = _login(client)
-        u1 = _propose(client, domain=["status-test"])
-        _propose(client, domain=["status-test"])
+        u1 = _propose(client, domains=["status-test"])
+        _propose(client, domains=["status-test"])
         client.post(f"/review/{u1['id']}/approve", headers=_auth_header(token))
         resp = client.get(
             "/review/units",
@@ -254,8 +254,8 @@ class TestReviewStats:
 
     def test_domains_count_approved_only(self, client: TestClient) -> None:
         token = _login(client)
-        u1 = _propose(client, domain=["only-approved"])
-        u2 = _propose(client, domain=["only-approved"])
+        u1 = _propose(client, domains=["only-approved"])
+        u2 = _propose(client, domains=["only-approved"])
         client.post(f"/review/{u1['id']}/approve", headers=_auth_header(token))
         client.post(f"/review/{u2['id']}/reject", headers=_auth_header(token))
         resp = client.get("/review/stats", headers=_auth_header(token))

--- a/server/backend/tests/test_store.py
+++ b/server/backend/tests/test_store.py
@@ -31,7 +31,7 @@ def _make_insight(**overrides: Any) -> Insight:
 
 def _make_unit(**overrides: Any) -> KnowledgeUnit:
     defaults = {
-        "domain": ["databases", "performance"],
+        "domains": ["databases", "performance"],
         "insight": _make_insight(),
     }
     return create_knowledge_unit(**{**defaults, **overrides})
@@ -69,7 +69,7 @@ class TestInsertAndGet:
         assert store.get("ku_nonexistent") is None
 
     def test_insert_with_empty_domains_raises(self, store: TeamStore) -> None:
-        unit = _make_unit(domain=["  ", ""])
+        unit = _make_unit(domains=["  ", ""])
         with pytest.raises(ValueError, match="At least one non-empty domain"):
             store.insert(unit)
 
@@ -89,33 +89,33 @@ class TestUpdate:
             store.update(unit)
 
     def test_update_with_empty_domains_raises(self, store: TeamStore) -> None:
-        unit = _make_unit(domain=["databases"])
+        unit = _make_unit(domains=["databases"])
         store.insert(unit)
-        updated = unit.model_copy(update={"domain": ["  "]})
+        updated = unit.model_copy(update={"domains": ["  "]})
         with pytest.raises(ValueError, match="At least one non-empty domain"):
             store.update(updated)
 
 
 class TestQuery:
     def test_returns_matching_units(self, store: TeamStore) -> None:
-        unit = _insert_and_approve(store, domain=["databases"])
+        unit = _insert_and_approve(store, domains=["databases"])
         results = store.query(["databases"])
         assert len(results) == 1
         assert results[0].id == unit.id
 
     def test_returns_empty_for_no_match(self, store: TeamStore) -> None:
-        _insert_and_approve(store, domain=["databases"])
+        _insert_and_approve(store, domains=["databases"])
         assert store.query(["networking"]) == []
 
     def test_language_filter_boosts_matching_units(self, store: TeamStore) -> None:
         py = _insert_and_approve(
             store,
-            domain=["web"],
+            domains=["web"],
             context=Context(languages=["python"]),
         )
         go = _insert_and_approve(
             store,
-            domain=["web"],
+            domains=["web"],
             context=Context(languages=["go"]),
         )
         results = store.query(["web"], language="python")
@@ -125,24 +125,24 @@ class TestQuery:
 
     def test_language_filter_includes_units_without_language(self, store: TeamStore) -> None:
         """KUs with no language set should still appear when language filter is used."""
-        no_lang = _insert_and_approve(store, domain=["ci"])
+        no_lang = _insert_and_approve(store, domains=["ci"])
         results = store.query(["ci"], language="python")
         assert len(results) == 1
         assert results[0].id == no_lang.id
 
     def test_framework_filter_includes_units_without_framework(self, store: TeamStore) -> None:
         """KUs with no framework set should still appear when framework filter is used."""
-        no_fw = _insert_and_approve(store, domain=["web"])
+        no_fw = _insert_and_approve(store, domains=["web"])
         results = store.query(["web"], framework="fastapi")
         assert len(results) == 1
         assert results[0].id == no_fw.id
 
     def test_language_filter_ranks_matching_higher(self, store: TeamStore) -> None:
         """KUs with matching language should rank above those without."""
-        no_lang = _insert_and_approve(store, domain=["web"])
+        no_lang = _insert_and_approve(store, domains=["web"])
         with_lang = _insert_and_approve(
             store,
-            domain=["web"],
+            domains=["web"],
             context=Context(languages=["python"]),
         )
         results = store.query(["web"], language="python")
@@ -160,13 +160,13 @@ class TestStats:
         assert store.count() == 0
 
     def test_count_after_inserts(self, store: TeamStore) -> None:
-        store.insert(_make_unit(domain=["a"]))
-        store.insert(_make_unit(domain=["b"]))
+        store.insert(_make_unit(domains=["a"]))
+        store.insert(_make_unit(domains=["b"]))
         assert store.count() == 2
 
     def test_domain_counts(self, store: TeamStore) -> None:
-        u1 = _make_unit(domain=["api", "payments"])
-        u2 = _make_unit(domain=["api", "auth"])
+        u1 = _make_unit(domains=["api", "payments"])
+        u2 = _make_unit(domains=["api", "auth"])
         store.insert(u1)
         store.insert(u2)
         store.set_review_status(u1.id, "approved", "tester")
@@ -190,20 +190,20 @@ class TestReviewStatus:
 
 class TestStatusFiltering:
     def test_query_excludes_pending_units(self, store: TeamStore) -> None:
-        unit = _make_unit(domain=["api"])
+        unit = _make_unit(domains=["api"])
         store.insert(unit)
         results = store.query(["api"])
         assert len(results) == 0
 
     def test_query_returns_approved_units(self, store: TeamStore) -> None:
-        unit = _make_unit(domain=["api"])
+        unit = _make_unit(domains=["api"])
         store.insert(unit)
         store.set_review_status(unit.id, "approved", "reviewer")
         results = store.query(["api"])
         assert len(results) == 1
 
     def test_query_excludes_rejected_units(self, store: TeamStore) -> None:
-        unit = _make_unit(domain=["api"])
+        unit = _make_unit(domains=["api"])
         store.insert(unit)
         store.set_review_status(unit.id, "rejected", "reviewer")
         results = store.query(["api"])
@@ -223,32 +223,32 @@ class TestStatusFiltering:
 
 class TestReviewQueue:
     def test_pending_queue_returns_pending_units(self, store: TeamStore) -> None:
-        u1 = _make_unit(domain=["api"])
-        u2 = _make_unit(domain=["db"])
+        u1 = _make_unit(domains=["api"])
+        u2 = _make_unit(domains=["db"])
         store.insert(u1)
         store.insert(u2)
         queue = store.pending_queue(limit=20, offset=0)
         assert len(queue) == 2
 
     def test_pending_queue_excludes_reviewed(self, store: TeamStore) -> None:
-        unit = _make_unit(domain=["api"])
+        unit = _make_unit(domains=["api"])
         store.insert(unit)
         store.set_review_status(unit.id, "approved", "reviewer")
         queue = store.pending_queue(limit=20, offset=0)
         assert len(queue) == 0
 
     def test_pending_count(self, store: TeamStore) -> None:
-        u1 = _make_unit(domain=["a"])
-        u2 = _make_unit(domain=["b"])
+        u1 = _make_unit(domains=["a"])
+        u2 = _make_unit(domains=["b"])
         store.insert(u1)
         store.insert(u2)
         store.set_review_status(u1.id, "approved", "reviewer")
         assert store.pending_count() == 1
 
     def test_counts_by_status(self, store: TeamStore) -> None:
-        u1 = _make_unit(domain=["a"])
-        u2 = _make_unit(domain=["b"])
-        u3 = _make_unit(domain=["c"])
+        u1 = _make_unit(domains=["a"])
+        u2 = _make_unit(domains=["b"])
+        u3 = _make_unit(domains=["c"])
         store.insert(u1)
         store.insert(u2)
         store.insert(u3)
@@ -260,8 +260,8 @@ class TestReviewQueue:
         assert counts["pending"] == 1
 
     def test_daily_counts(self, store: TeamStore) -> None:
-        store.insert(_make_unit(domain=["a"]))
-        store.insert(_make_unit(domain=["b"]))
+        store.insert(_make_unit(domains=["a"]))
+        store.insert(_make_unit(domains=["b"]))
         counts = store.daily_counts(days=30)
         assert len(counts) >= 1
         total = sum(row["proposed"] for row in counts)
@@ -270,7 +270,7 @@ class TestReviewQueue:
     def test_daily_counts_gap_fills_to_today(self, store: TeamStore) -> None:
         """daily_counts should return contiguous dates from the earliest entry to today."""
         three_days_ago = datetime.now(UTC) - timedelta(days=3)
-        unit = _make_unit(domain=["a"])
+        unit = _make_unit(domains=["a"])
         unit.evidence.first_observed = three_days_ago
         unit.evidence.last_confirmed = three_days_ago
         store.insert(unit)
@@ -296,12 +296,12 @@ class TestReviewQueue:
         three_days_ago = datetime.now(UTC) - timedelta(days=3)
         one_day_ago = datetime.now(UTC) - timedelta(days=1)
 
-        u1 = _make_unit(domain=["a"])
+        u1 = _make_unit(domains=["a"])
         u1.evidence.first_observed = three_days_ago
         u1.evidence.last_confirmed = three_days_ago
         store.insert(u1)
 
-        u2 = _make_unit(domain=["b"])
+        u2 = _make_unit(domains=["b"])
         u2.evidence.first_observed = three_days_ago
         u2.evidence.last_confirmed = three_days_ago
         store.insert(u2)
@@ -331,7 +331,7 @@ class TestReviewQueue:
         """daily_counts should include rejected counts grouped by reviewed_at date."""
         two_days_ago = datetime.now(UTC) - timedelta(days=2)
 
-        unit = _make_unit(domain=["a"])
+        unit = _make_unit(domains=["a"])
         unit.evidence.first_observed = two_days_ago
         unit.evidence.last_confirmed = two_days_ago
         store.insert(unit)
@@ -362,7 +362,7 @@ class TestReviewQueue:
 
     def test_pending_queue_pagination(self, store: TeamStore) -> None:
         for _ in range(3):
-            store.insert(_make_unit(domain=["a"]))
+            store.insert(_make_unit(domains=["a"]))
         page1 = store.pending_queue(limit=2, offset=0)
         page2 = store.pending_queue(limit=2, offset=2)
         assert len(page1) == 2
@@ -379,7 +379,7 @@ class TestEndToEnd:
     def test_propose_confirm_flag_lifecycle(self, store: TeamStore) -> None:
         _insert_and_approve(
             store,
-            domain=["api", "payments"],
+            domains=["api", "payments"],
             context=Context(languages=["python"], frameworks=["fastapi"]),
             tier=Tier.TEAM,
         )

--- a/server/scripts/seed-kus.json
+++ b/server/scripts/seed-kus.json
@@ -2,7 +2,7 @@
   {
     "_comment": "API quirks",
     "_target_confidence": 0.9,
-    "domain": ["api", "stripe", "rate-limiting"],
+    "domains": ["api", "stripe", "rate-limiting"],
     "insight": {
       "summary": "Stripe API returns HTTP 200 with an error body when a request is rate-limited",
       "detail": "When rate-limited, Stripe does not return a 429. Instead it returns a 200 response whose JSON body contains an error object with type 'invalid_request_error' and code 'rate_limit'. Checking only the HTTP status code will cause rate-limit errors to be silently ignored and treated as success.",
@@ -18,7 +18,7 @@
   {
     "_comment": "API quirks",
     "_target_confidence": 0.7,
-    "domain": ["api", "github", "search"],
+    "domains": ["api", "github", "search"],
     "insight": {
       "summary": "GitHub Search API returns 422 when query strings contain unquoted special characters such as colons or slashes",
       "detail": "The GitHub Search API parses query strings using its own qualifier syntax. Characters like ':', '/', and '.' have special meaning. Passing user-supplied strings without quoting them causes a 422 Unprocessable Entity with the message 'Validation Failed'. This is not documented clearly in the API reference.",
@@ -34,7 +34,7 @@
   {
     "_comment": "API quirks",
     "_target_confidence": 0.8,
-    "domain": ["api", "aws", "s3", "pagination"],
+    "domains": ["api", "aws", "s3", "pagination"],
     "insight": {
       "summary": "AWS S3 ListObjectsV2 silently truncates results at 1000 objects",
       "detail": "S3 ListObjectsV2 returns at most 1000 keys per call. If the bucket contains more objects, the response sets IsTruncated=true and provides a NextContinuationToken. Code that does not check IsTruncated will silently miss objects beyond the first 1000 with no error or warning.",
@@ -50,7 +50,7 @@
   {
     "_comment": "API quirks",
     "_target_confidence": 0.8,
-    "domain": ["api", "github", "github-actions", "tokens"],
+    "domains": ["api", "github", "github-actions", "tokens"],
     "insight": {
       "summary": "The GITHUB_TOKEN in GitHub Actions cannot trigger other workflow runs",
       "detail": "Workflows triggered by a GITHUB_TOKEN-authenticated push or tag creation do not fire other workflow triggers. This is a deliberate GitHub restriction to prevent recursive workflow loops. PATs or GitHub App tokens are required to trigger downstream workflows from within a workflow.",
@@ -66,7 +66,7 @@
   {
     "_comment": "Library gotchas",
     "_target_confidence": 0.7,
-    "domain": ["http", "python", "requests", "redirects"],
+    "domains": ["http", "python", "requests", "redirects"],
     "insight": {
       "summary": "Python requests changes POST to GET when following a 301 or 302 redirect",
       "detail": "RFC 2616 allows clients to change the method from POST to GET on 301/302 redirects, and requests follows this behaviour. A POST to an endpoint that redirects will silently become a GET, dropping the request body. This can result in data not being submitted without any error being raised.",
@@ -82,7 +82,7 @@
   {
     "_comment": "Library gotchas",
     "_target_confidence": 0.8,
-    "domain": ["python", "datetime", "timezone"],
+    "domains": ["python", "datetime", "timezone"],
     "insight": {
       "summary": "datetime.utcnow() returns a naive datetime with no timezone info and is deprecated in Python 3.12",
       "detail": "datetime.utcnow() returns a datetime object with no tzinfo, making it indistinguishable from a local time in arithmetic and comparisons. Python 3.12 deprecated it with a DeprecationWarning. Code using utcnow() mixed with timezone-aware datetimes raises TypeError.",
@@ -98,7 +98,7 @@
   {
     "_comment": "Library gotchas",
     "_target_confidence": 0.9,
-    "domain": ["python", "pydantic", "migration"],
+    "domains": ["python", "pydantic", "migration"],
     "insight": {
       "summary": "Pydantic v2 removed model.dict() and model.json(); use model.model_dump() and model.model_dump_json()",
       "detail": "Pydantic v2 is a near-complete rewrite with a breaking API. The dict() and json() instance methods were removed. In v2, use model.model_dump() and model.model_dump_json(). Additionally, validators use @field_validator instead of @validator, and model_config replaces the inner Config class. Importing from pydantic.v1 is available as a compatibility shim but should not be used in new code.",
@@ -114,7 +114,7 @@
   {
     "_comment": "Library gotchas",
     "_target_confidence": 0.7,
-    "domain": ["node", "npm", "ci", "lockfile"],
+    "domains": ["node", "npm", "ci", "lockfile"],
     "insight": {
       "summary": "npm ci fails if package-lock.json is absent or out of sync with package.json",
       "detail": "Unlike npm install, npm ci requires a package-lock.json to exist and will exit with an error if package.json dependencies do not exactly match the lockfile. It also deletes node_modules before installing. This makes CI builds reproducible but means any uncommitted lockfile change will break the build.",
@@ -130,7 +130,7 @@
   {
     "_comment": "CI/CD traps",
     "_target_confidence": 0.9,
-    "domain": ["ci", "github-actions", "secrets", "security"],
+    "domains": ["ci", "github-actions", "secrets", "security"],
     "insight": {
       "summary": "GitHub Actions secrets are not available in workflows triggered by pull requests from forks",
       "detail": "For security, GitHub does not pass repository secrets to workflow runs triggered by pull_request events from forked repositories. The secrets context is empty. This affects any CI step that needs an API key, deployment credential, or registry password. The workflow runs but silently uses empty strings, which can cause confusing authentication failures.",
@@ -146,7 +146,7 @@
   {
     "_comment": "CI/CD traps",
     "_target_confidence": 0.8,
-    "domain": ["ci", "docker", "layer-cache", "performance"],
+    "domains": ["ci", "docker", "layer-cache", "performance"],
     "insight": {
       "summary": "Placing COPY . . before dependency installation in a Dockerfile invalidates the layer cache on every code change",
       "detail": "Docker rebuilds all layers from the first changed layer onwards. If source code is copied before dependencies are installed, any code change triggers a full dependency reinstall. Since code changes far more often than dependency specs, this makes builds unnecessarily slow.",
@@ -162,7 +162,7 @@
   {
     "_comment": "CI/CD traps",
     "_target_confidence": 0.8,
-    "domain": ["ci", "rust", "github-actions", "toolchain"],
+    "domains": ["ci", "rust", "github-actions", "toolchain"],
     "insight": {
       "summary": "rust-toolchain.toml is silently ignored when a GitHub Actions matrix sets the toolchain via dtolnay/rust-toolchain",
       "detail": "When a workflow uses a matrix to test multiple Rust toolchain versions and passes the toolchain version as an input to dtolnay/rust-toolchain, that action overrides rust-toolchain.toml. The file is not read. This means the matrix-specified toolchain is used, not the pinned version in the file, leading to version inconsistencies between local and CI builds.",
@@ -178,7 +178,7 @@
   {
     "_comment": "CI/CD traps",
     "_target_confidence": 0.6,
-    "domain": ["ci", "github-actions", "git", "versioning"],
+    "domains": ["ci", "github-actions", "git", "versioning"],
     "insight": {
       "summary": "actions/checkout fetches only a single commit by default, breaking tag-based version detection",
       "detail": "By default, actions/checkout performs a shallow clone (fetch-depth: 1). Tools that compute versions from git tags (e.g. setuptools-scm, dunamai, git describe) cannot see any tags in a shallow clone and fall back to a default or raise an error. This produces incorrect version strings in release artefacts.",
@@ -194,7 +194,7 @@
   {
     "_comment": "Framework patterns",
     "_target_confidence": 0.7,
-    "domain": ["python", "fastapi", "async", "background-tasks"],
+    "domains": ["python", "fastapi", "async", "background-tasks"],
     "insight": {
       "summary": "FastAPI BackgroundTasks run after the response has been sent; the request context is no longer available",
       "detail": "Functions added via BackgroundTasks run in the same event loop but after the response is returned to the client. Any dependencies injected via Depends() that are scoped to the request have already been cleaned up. Attempting to use a request-scoped database session or auth context in a background task will raise errors or produce undefined behaviour.",
@@ -210,7 +210,7 @@
   {
     "_comment": "Framework patterns",
     "_target_confidence": 0.8,
-    "domain": ["database", "sqlite", "concurrency"],
+    "domains": ["database", "sqlite", "concurrency"],
     "insight": {
       "summary": "SQLite requires WAL journal mode for concurrent read access alongside writes",
       "detail": "In the default DELETE journal mode, SQLite acquires an exclusive lock during writes, blocking all readers. WAL (Write-Ahead Logging) mode allows concurrent reads during a write by separating the write-ahead log from the main database file. Without WAL, multi-threaded or multi-process applications see 'database is locked' errors under write load.",
@@ -226,7 +226,7 @@
   {
     "_comment": "Framework patterns",
     "_target_confidence": 0.7,
-    "domain": ["react", "javascript", "typescript", "hooks"],
+    "domains": ["react", "javascript", "typescript", "hooks"],
     "insight": {
       "summary": "Passing an async function directly to useEffect silently swallows the cleanup return value",
       "detail": "React expects useEffect to return either undefined or a synchronous cleanup function. An async function returns a Promise, not undefined or a function. React ignores the Promise, so cleanup never runs. This causes memory leaks, state updates on unmounted components, and missed cancellations of in-flight requests.",
@@ -243,7 +243,7 @@
     "_comment": "Low-confidence / disputed — stale guidance",
     "_target_confidence": 0.35,
     "_flag_reason": "stale",
-    "domain": ["aws", "lambda", "performance", "cold-start"],
+    "domains": ["aws", "lambda", "performance", "cold-start"],
     "insight": {
       "summary": "AWS Lambda cold start latency can be reduced by keeping functions warm with scheduled EventBridge pings",
       "detail": "Lambda functions that are not invoked for several minutes are de-provisioned, causing the next invocation to incur a cold start. A common workaround was to schedule CloudWatch Events/EventBridge rules to invoke the function every 5 minutes to keep execution environments alive.",
@@ -260,7 +260,7 @@
     "_comment": "Low-confidence / disputed — stale guidance",
     "_target_confidence": 0.2,
     "_flag_reason": "stale",
-    "domain": ["python", "pip", "packaging"],
+    "domains": ["python", "pip", "packaging"],
     "insight": {
       "summary": "Use pip install --user when system Python is read-only to install packages without root",
       "detail": "On systems where the system Python site-packages directory is not writable, pip install fails with a permission error. The --user flag installs packages into ~/.local/lib/pythonX.Y/site-packages, which is always user-writable.",


### PR DESCRIPTION
## Summary
- Rename `domain` → `domains` on `KnowledgeUnit`, `ProposeRequest`,
  and the `GET /query` query parameter to match the SDK contract.
- Rename `normalise_domains` → `normalize_domains` (US spelling).
- Update seed data and all tests.

Closes #177

## Test plan
- [x] All 95 server backend tests pass
- [x] Python linting and type checking pass