### PR TITLE
Fix GoReleaser tag mismatch for prefixed cli/ tags

### DIFF
--- a/.github/workflows/release-go-cli.yaml
+++ b/.github/workflows/release-go-cli.yaml
@@ -51,12 +51,6 @@ jobs:
 
           {
             echo "GORELEASER_CURRENT_TAG<<EOF"
-            echo "$VERSION"
-            echo "EOF"
-          } >> "$GITHUB_ENV"
-
-          {
-            echo "RELEASE_TAG<<EOF"
             echo "$TAG"
             echo "EOF"
           } >> "$GITHUB_ENV"
@@ -68,7 +62,7 @@ jobs:
 
       - name: Checkout release tag
         env:
-          TAG: ${{ env.RELEASE_TAG }}
+          TAG: ${{ env.GORELEASER_CURRENT_TAG }}
         run: |
           git fetch --tags
           if ! git rev-parse "$TAG" >/dev/null 2>&1; then

--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -6,6 +6,9 @@ version: 2
 
 project_name: cq
 
+monorepo:
+  tag_prefix: cli/
+
 before:
   hooks:
     - cd ../sdk/go && make sync-skill


### PR DESCRIPTION
## Summary

- Add `monorepo.tag_prefix: cli/` to GoReleaser config so it understands prefixed tags
- Pass full tag (`cli/v0.1.0`) as `GORELEASER_CURRENT_TAG` instead of stripped version (`v0.1.0`)
- Remove unused `RELEASE_TAG` env var

Fixes the `git tag v0.1.0 was not made against commit ...` error from
https://github.com/mozilla-ai/cq/actions/runs/23851301337/job/69531875748

## Test plan

- [ ] Re-tag `cli/v0.1.0` and create release; verify goreleaser job succeeds
- [ ] Verify `sdk/go/*` releases still skip the CLI workflow