### PR TITLE
Fix GoReleaser before hook using shell builtin

### DIFF
--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -8,7 +8,7 @@ project_name: cq
 
 before:
   hooks:
-    - cd ../sdk/go && make sync-skill
+    - make -C ../sdk/go sync-skill
     - go mod tidy
 
 builds:


### PR DESCRIPTION
## Summary

- Replace `cd ../sdk/go && make sync-skill` with `make -C ../sdk/go sync-skill`
- GoReleaser exec's hooks directly, not through a shell, so `cd` is unavailable

Tested locally with `goreleaser release --snapshot --clean --skip publish --skip homebrew`; all 4 binaries built successfully.

## Test plan

- [ ] Merge, tag `cli/v0.1.0`, create release; verify goreleaser job passes the hook stage