### PR TITLE
Fix LICENSE path in GoReleaser archive config

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,0 +1,2 @@
+# Copied from repo root by GoReleaser before hook.
+LICENSE

--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -9,6 +9,7 @@ project_name: cq
 before:
   hooks:
     - make -C ../sdk/go sync-skill
+    - cp ../LICENSE LICENSE
     - go mod tidy
 
 builds:
@@ -43,8 +44,7 @@ archives:
     files:
       - NOTICE
       - README.md
-      - src: ../LICENSE
-        dst: .
+      - LICENSE
 
 homebrew_casks:
   - name: cq


### PR DESCRIPTION
## Summary

- Copy LICENSE from repo root into cli/ via a before hook, replacing the broken `../LICENSE` relative path
- Add cli/.gitignore to exclude the copied LICENSE from version control
- GoReleaser cannot resolve parent-relative paths from its workdir

Tested locally with `goreleaser release --snapshot --clean --skip publish --skip homebrew`; full release succeeded.

## Test plan

- [ ] Merge, tag `cli/v0.1.0`, create release; verify goreleaser completes successfully