### PR TITLE
Sync frontend types and migration with cq-sdk v0.3.0

### DIFF
--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -61,5 +61,15 @@ jobs:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
 
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: server/frontend/pnpm-lock.yaml
+
       - name: Setup and test
         run: make setup-server test-server

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ help:
 	@echo "    - make test-sdk-python      Python SDK"
 	@echo "    - make test-server          Server"
 	@echo "      - make test-server-backend  Backend"
+	@echo "      - make test-server-frontend Frontend"
 	@echo "  make validate-schema        Validate JSON Schema fixtures"
 	@echo ""
 	@echo "Docker Compose:"
@@ -203,8 +204,12 @@ test-sdk-python:
 test-server-backend: validate-schema
 	cd server/backend && uv run pytest
 
+.PHONY: test-server-frontend
+test-server-frontend:
+	cd server/frontend && pnpm test
+
 .PHONY: test-server
-test-server: test-server-backend
+test-server: test-server-backend test-server-frontend
 
 .PHONY: test
 test: test-cli test-sdk-go test-sdk-python test-server

--- a/server/frontend/src/components/FilteredListModal.tsx
+++ b/server/frontend/src/components/FilteredListModal.tsx
@@ -128,7 +128,7 @@ export function FilteredListModal({ filter, onClose, onSelectUnit }: Props) {
                     </span>
                   </div>
                   <div className="flex items-center gap-3">
-                    <DomainTags domains={item.knowledge_unit.domain} />
+                    <DomainTags domains={item.knowledge_unit.domains} />
                     <span className="text-xs text-gray-400 ml-auto shrink-0">
                       {confidenceLabel(item.knowledge_unit.evidence.confidence)}
                     </span>

--- a/server/frontend/src/components/KnowledgeUnitModal.tsx
+++ b/server/frontend/src/components/KnowledgeUnitModal.tsx
@@ -120,7 +120,7 @@ export function KnowledgeUnitModal({ unitId, onClose }: Props) {
               )}
             </div>
 
-            <DomainTags domains={item.knowledge_unit.domain} />
+            <DomainTags domains={item.knowledge_unit.domains} />
 
             <p className="text-gray-600 leading-relaxed">
               {item.knowledge_unit.insight.detail}
@@ -172,7 +172,9 @@ export function KnowledgeUnitModal({ unitId, onClose }: Props) {
 
             <div className="flex items-center justify-between text-xs text-gray-400 pt-2 border-t border-gray-100">
               <span className="font-mono">{item.knowledge_unit.id}</span>
-              <span>{timeAgo(item.knowledge_unit.evidence.first_observed)}</span>
+              {item.knowledge_unit.evidence.first_observed && (
+                <span>{timeAgo(item.knowledge_unit.evidence.first_observed)}</span>
+              )}
             </div>
           </div>
         )}

--- a/server/frontend/src/components/ReviewCard.tsx
+++ b/server/frontend/src/components/ReviewCard.tsx
@@ -59,10 +59,12 @@ export const ReviewCard = forwardRef<HTMLDivElement, Props>(
         {...pointerHandlers}
       >
         <div className="flex items-center justify-between mb-3">
-          <DomainTags domains={unit.domain} variant={activeState} />
-          <span className="text-xs text-gray-400">
-            {timeAgo(unit.evidence.first_observed)}
-          </span>
+          <DomainTags domains={unit.domains} variant={activeState} />
+          {unit.evidence.first_observed && (
+            <span className="text-xs text-gray-400">
+              {timeAgo(unit.evidence.first_observed)}
+            </span>
+          )}
         </div>
 
         <h2 className="text-lg font-semibold text-gray-900 mb-2">

--- a/server/frontend/src/types.ts
+++ b/server/frontend/src/types.ts
@@ -13,19 +13,28 @@ export interface Context {
 export interface Evidence {
   confidence: number;
   confirmations: number;
-  first_observed: string;
-  last_confirmed: string;
+  first_observed: string | null;
+  last_confirmed: string | null;
+}
+
+export interface Flag {
+  reason: "stale" | "incorrect" | "duplicate";
+  timestamp: string;
+  detail: string | null;
+  duplicate_of: string | null;
 }
 
 export interface KnowledgeUnit {
   id: string;
   version: number;
-  domain: string[];
+  domains: string[];
   insight: Insight;
   context: Context;
   evidence: Evidence;
   tier: string;
   created_by: string;
+  superseded_by: string | null;
+  flags: Flag[];
 }
 
 export interface ReviewItem {

--- a/server/scripts/migrate-v1.sh
+++ b/server/scripts/migrate-v1.sh
@@ -15,7 +15,8 @@
 #   4. ${XDG_DATA_HOME:-$HOME/.local/share}/cq/local.db
 #
 # Transformations applied:
-#   - Tier values:   TIER_LOCAL → local, TIER_PRIVATE → private, TIER_PUBLIC → public
+#   - Tier values:   TIER_LOCAL → local, TIER_PRIVATE → private, TIER_PUBLIC → public,
+#                    team → private, global → public (server legacy values)
 #   - Flag reasons:  FLAG_REASON_STALE → stale, FLAG_REASON_INCORRECT → incorrect,
 #                    FLAG_REASON_DUPLICATE → duplicate
 #   - Field rename:  "domain" (singular) → "domains" (plural) in JSON data
@@ -60,7 +61,7 @@ count_legacy_rows() {
     sqlite3 "$db_path" <<'SQL'
 SELECT
     (SELECT COUNT(*) FROM knowledge_units
-     WHERE json_extract(data, '$.tier') IN ('TIER_LOCAL','TIER_PRIVATE','TIER_PUBLIC'))
+     WHERE json_extract(data, '$.tier') IN ('TIER_LOCAL','TIER_PRIVATE','TIER_PUBLIC','team','global'))
     || '|' ||
     (SELECT COUNT(*) FROM knowledge_units
      WHERE data LIKE '%FLAG_REASON_%')
@@ -133,15 +134,18 @@ PRAGMA foreign_keys = OFF;
 BEGIN TRANSACTION;
 
 -- Normalise tier enum values using targeted JSON path replacement.
+-- Handles both Go SDK prefixed values and server legacy values.
 UPDATE knowledge_units
 SET data = json_set(data, '$.tier',
     CASE json_extract(data, '$.tier')
         WHEN 'TIER_LOCAL'   THEN 'local'
         WHEN 'TIER_PRIVATE' THEN 'private'
         WHEN 'TIER_PUBLIC'  THEN 'public'
+        WHEN 'team'         THEN 'private'
+        WHEN 'global'       THEN 'public'
     END
 )
-WHERE json_extract(data, '$.tier') IN ('TIER_LOCAL', 'TIER_PRIVATE', 'TIER_PUBLIC');
+WHERE json_extract(data, '$.tier') IN ('TIER_LOCAL', 'TIER_PRIVATE', 'TIER_PUBLIC', 'team', 'global');
 
 -- Normalise flag reason enum values.
 -- Uses string replacement because SQLite lacks ergonomic JSON array-element
@@ -217,7 +221,7 @@ verify_migration() {
     remaining=$(sqlite3 "$db_path" <<'SQL'
 SELECT
     (SELECT COUNT(*) FROM knowledge_units
-     WHERE json_extract(data, '$.tier') IN ('TIER_LOCAL','TIER_PRIVATE','TIER_PUBLIC'))
+     WHERE json_extract(data, '$.tier') IN ('TIER_LOCAL','TIER_PRIVATE','TIER_PUBLIC','team','global'))
     +
     (SELECT COUNT(*) FROM knowledge_units
      WHERE data LIKE '%FLAG_REASON_%')

--- a/server/scripts/migrate-v1_test.sh
+++ b/server/scripts/migrate-v1_test.sh
@@ -219,6 +219,38 @@ test_tier_public() {
     assert_eq "$tier" "public" "TIER_PUBLIC should become public"
 }
 
+test_tier_team() {
+    local dir="$1"
+    local db
+    db=$(create_team_db "$dir")
+
+    insert_ku "$db" "ku_00000000000000000000000000000001" \
+        '{"id":"ku_00000000000000000000000000000001","version":1,"domains":["api"],"tier":"team","insight":{"summary":"s","detail":"d","action":"a"},"context":{},"evidence":{"confidence":0.5},"flags":[]}' \
+        "api"
+
+    bash "$MIGRATE" "$db" >/dev/null
+
+    local tier
+    tier=$(read_field "$db" "ku_00000000000000000000000000000001" '$.tier')
+    assert_eq "$tier" "private" "team should become private"
+}
+
+test_tier_global() {
+    local dir="$1"
+    local db
+    db=$(create_team_db "$dir")
+
+    insert_ku "$db" "ku_00000000000000000000000000000001" \
+        '{"id":"ku_00000000000000000000000000000001","version":1,"domains":["api"],"tier":"global","insight":{"summary":"s","detail":"d","action":"a"},"context":{},"evidence":{"confidence":0.5},"flags":[]}' \
+        "api"
+
+    bash "$MIGRATE" "$db" >/dev/null
+
+    local tier
+    tier=$(read_field "$db" "ku_00000000000000000000000000000001" '$.tier')
+    assert_eq "$tier" "public" "global should become public"
+}
+
 test_flag_reason_stale() {
     local dir="$1"
     local db
@@ -574,6 +606,8 @@ main() {
     run_test "tier: TIER_LOCAL → local"                     test_tier_local
     run_test "tier: TIER_PRIVATE → private"                 test_tier_private
     run_test "tier: TIER_PUBLIC → public"                   test_tier_public
+    run_test "tier: team → private"                         test_tier_team
+    run_test "tier: global → public"                        test_tier_global
     run_test "flag: FLAG_REASON_STALE → stale"              test_flag_reason_stale
     run_test "flag: FLAG_REASON_INCORRECT → incorrect"      test_flag_reason_incorrect
     run_test "flag: FLAG_REASON_DUPLICATE → duplicate"      test_flag_reason_duplicate


### PR DESCRIPTION
## Summary

- Sync frontend TypeScript types with cq-sdk v0.3.0 models (`domain` -> `domains`, add `Flag`, `superseded_by`, `flags`, nullable timestamps)
- Fix three components referencing `unit.domain` instead of `unit.domains`
- Add `team -> private` and `global -> public` tier mappings to `migrate-v1.sh` for server legacy data
- Add `test-server-frontend` Makefile target and wire it into CI

Follows up on #219 which replaced server models with cq-sdk but did not update the frontend or migration script.

## Test plan

- [x] `make lint-server-frontend` passes
- [x] `make test-server-frontend` passes (8 tests)
- [x] `migrate-v1_test.sh` passes (23 tests, including 2 new tier tests)
- [x] Migration run on live container; 14 rows fixed, no more 500s
- [ ] Verify review UI renders domain tags correctly after migration