### PR TITLE
Bump marketplace plugin version to 0.5.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "cq",
       "source": "./plugins/cq",
       "description": "Shared knowledge commons for AI agents; find, share, and confirm collective knowledge to stop rediscovering the same failures.",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "category": "knowledge",
       "tags": ["knowledge-sharing", "agent-learning", "agent-commons","mcp", "pitfall-avoidance", "team-knowledge", "api-quirks"]
     }


### PR DESCRIPTION
## Summary

- Bump marketplace.json plugin version from 0.4.0 to 0.5.0 to match plugin.json and pyproject.toml

## Test plan

- [x] Verify version matches `plugins/cq/.claude-plugin/plugin.json` (0.5.0)
- [x] Verify version matches `plugins/cq/pyproject.toml` (0.5.0)