### PR TITLE
Accept plural languages/frameworks in server query API

### DIFF
--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -84,13 +84,13 @@ def health() -> dict[str, str]:
 @app.get("/query")
 def query_units(
     domains: Annotated[list[str], Query()],
-    language: Annotated[str | None, Query()] = None,
-    framework: Annotated[str | None, Query()] = None,
+    languages: Annotated[list[str] | None, Query()] = None,
+    frameworks: Annotated[list[str] | None, Query()] = None,
     limit: Annotated[int, Query(gt=0)] = 5,
 ) -> list[KnowledgeUnit]:
     """Search knowledge units by domain tags with relevance ranking."""
     store = _get_store()
-    return store.query(domains, language=language, framework=framework, limit=limit)
+    return store.query(domains, languages=languages, frameworks=frameworks, limit=limit)
 
 
 @app.post("/propose", status_code=201)

--- a/server/backend/src/cq_server/scoring.py
+++ b/server/backend/src/cq_server/scoring.py
@@ -42,13 +42,14 @@ def apply_flag(unit: KnowledgeUnit, reason: FlagReason) -> KnowledgeUnit:
 def calculate_relevance(
     unit: KnowledgeUnit,
     query_domains: list[str],
-    query_language: str | None = None,
-    query_framework: str | None = None,
+    query_languages: list[str] | None = None,
+    query_frameworks: list[str] | None = None,
 ) -> float:
     """Score relevance from 0.0 to 1.0 based on domain overlap and context match.
 
     Domain overlap is the primary signal (weighted at 0.7).
     Language and framework matches are secondary signals (0.15 each).
+    A unit scores 1.0 on language or framework if any queried value overlaps.
     """
     domain_weight = 0.7
     language_weight = 0.15
@@ -62,14 +63,14 @@ def calculate_relevance(
     else:
         domain_score = 0.0
 
-    # Language match is binary.
+    # Language match: 1.0 if any queried language appears in the unit.
     language_score = 0.0
-    if query_language and query_language in unit.context.languages:
+    if query_languages and set(query_languages) & set(unit.context.languages):
         language_score = 1.0
 
-    # Framework match is binary.
+    # Framework match: 1.0 if any queried framework appears in the unit.
     framework_score = 0.0
-    if query_framework and query_framework in unit.context.frameworks:
+    if query_frameworks and set(query_frameworks) & set(unit.context.frameworks):
         framework_score = 1.0
 
     return domain_weight * domain_score + language_weight * language_score + framework_weight * framework_score

--- a/server/backend/src/cq_server/store.py
+++ b/server/backend/src/cq_server/store.py
@@ -258,18 +258,18 @@ class TeamStore:
         self,
         domains: list[str],
         *,
-        language: str | None = None,
-        framework: str | None = None,
+        languages: list[str] | None = None,
+        frameworks: list[str] | None = None,
         limit: int = 5,
     ) -> list[KnowledgeUnit]:
         """Search for knowledge units by domain tags with relevance ranking.
 
         Args:
             domains: Domain tags to search for.
-            language: Optional language ranking signal. Matching KUs
-                rank higher but non-matching KUs are still returned.
-            framework: Optional framework ranking signal. Matching KUs
-                rank higher but non-matching KUs are still returned.
+            languages: Optional language ranking signal. KUs matching any
+                listed language rank higher but non-matching KUs are still returned.
+            frameworks: Optional framework ranking signal. KUs matching any
+                listed framework rank higher but non-matching KUs are still returned.
             limit: Maximum number of results to return. Must be positive.
 
         Returns:
@@ -311,8 +311,8 @@ class TeamStore:
             relevance = calculate_relevance(
                 unit,
                 normalized,
-                query_language=language,
-                query_framework=framework,
+                query_languages=languages,
+                query_frameworks=frameworks,
             )
             scored.append((relevance * unit.evidence.confidence, unit))
 

--- a/server/backend/tests/test_app.py
+++ b/server/backend/tests/test_app.py
@@ -115,11 +115,37 @@ class TestQuery:
             domains=["web"],
             context={"languages": ["go"], "frameworks": []},
         )
-        resp = client.get("/query", params={"domains": ["web"], "language": "python"})
+        resp = client.get("/query", params={"domains": ["web"], "languages": ["python"]})
         assert resp.status_code == 200
         results = resp.json()
         assert len(results) == 2
         assert "python" in results[0]["context"]["languages"]
+
+    def test_query_boosts_any_matching_language(self, client: TestClient) -> None:
+        self._insert_unit(
+            client,
+            domains=["web"],
+            context={"languages": ["python"], "frameworks": []},
+        )
+        self._insert_unit(
+            client,
+            domains=["web"],
+            context={"languages": ["go"], "frameworks": []},
+        )
+        self._insert_unit(
+            client,
+            domains=["web"],
+            context={"languages": ["rust"], "frameworks": []},
+        )
+        resp = client.get(
+            "/query",
+            params={"domains": ["web"], "languages": ["python", "go"]},
+        )
+        assert resp.status_code == 200
+        results = resp.json()
+        assert len(results) == 3
+        top_langs = {results[0]["context"]["languages"][0], results[1]["context"]["languages"][0]}
+        assert top_langs == {"python", "go"}
 
     def test_query_respects_limit(self, client: TestClient) -> None:
         for _ in range(3):
@@ -282,7 +308,7 @@ class TestEndToEnd:
         # Query returns the unit.
         resp = client.get(
             "/query",
-            params={"domains": ["api", "payments"], "language": "python"},
+            params={"domains": ["api", "payments"], "languages": ["python"]},
         )
         assert len(resp.json()) == 1
         assert resp.json()[0]["evidence"]["confidence"] == 0.5

--- a/server/backend/tests/test_store.py
+++ b/server/backend/tests/test_store.py
@@ -118,7 +118,7 @@ class TestQuery:
             domains=["web"],
             context=Context(languages=["go"]),
         )
-        results = store.query(["web"], language="python")
+        results = store.query(["web"], languages=["python"])
         assert len(results) == 2
         assert results[0].id == py.id
         assert results[1].id == go.id
@@ -126,14 +126,14 @@ class TestQuery:
     def test_language_filter_includes_units_without_language(self, store: TeamStore) -> None:
         """KUs with no language set should still appear when language filter is used."""
         no_lang = _insert_and_approve(store, domains=["ci"])
-        results = store.query(["ci"], language="python")
+        results = store.query(["ci"], languages=["python"])
         assert len(results) == 1
         assert results[0].id == no_lang.id
 
     def test_framework_filter_includes_units_without_framework(self, store: TeamStore) -> None:
         """KUs with no framework set should still appear when framework filter is used."""
         no_fw = _insert_and_approve(store, domains=["web"])
-        results = store.query(["web"], framework="fastapi")
+        results = store.query(["web"], frameworks=["fastapi"])
         assert len(results) == 1
         assert results[0].id == no_fw.id
 
@@ -145,10 +145,57 @@ class TestQuery:
             domains=["web"],
             context=Context(languages=["python"]),
         )
-        results = store.query(["web"], language="python")
+        results = store.query(["web"], languages=["python"])
         assert len(results) == 2
         assert results[0].id == with_lang.id
         assert results[1].id == no_lang.id
+
+    def test_multiple_languages_boost_any_match(self, store: TeamStore) -> None:
+        """Querying with multiple languages boosts units matching any of them."""
+        py = _insert_and_approve(
+            store,
+            domains=["web"],
+            context=Context(languages=["python"]),
+        )
+        go = _insert_and_approve(
+            store,
+            domains=["web"],
+            context=Context(languages=["go"]),
+        )
+        rust = _insert_and_approve(
+            store,
+            domains=["web"],
+            context=Context(languages=["rust"]),
+        )
+        results = store.query(["web"], languages=["python", "go"])
+        assert len(results) == 3
+        # Both python and go units rank above rust (no match).
+        matched_ids = {results[0].id, results[1].id}
+        assert matched_ids == {py.id, go.id}
+        assert results[2].id == rust.id
+
+    def test_multiple_frameworks_boost_any_match(self, store: TeamStore) -> None:
+        """Querying with multiple frameworks boosts units matching any of them."""
+        fastapi = _insert_and_approve(
+            store,
+            domains=["web"],
+            context=Context(frameworks=["fastapi"]),
+        )
+        django = _insert_and_approve(
+            store,
+            domains=["web"],
+            context=Context(frameworks=["django"]),
+        )
+        flask = _insert_and_approve(
+            store,
+            domains=["web"],
+            context=Context(frameworks=["flask"]),
+        )
+        results = store.query(["web"], frameworks=["fastapi", "django"])
+        assert len(results) == 3
+        matched_ids = {results[0].id, results[1].id}
+        assert matched_ids == {fastapi.id, django.id}
+        assert results[2].id == flask.id
 
     def test_rejects_non_positive_limit(self, store: TeamStore) -> None:
         with pytest.raises(ValueError, match="limit must be positive"):
@@ -384,7 +431,7 @@ class TestEndToEnd:
             tier=Tier.PRIVATE,
         )
 
-        results = store.query(["api", "payments"], language="python")
+        results = store.query(["api", "payments"], languages=["python"])
         assert len(results) == 1
         assert results[0].evidence.confidence == 0.5
 


### PR DESCRIPTION
## Summary

- Switch `/query` endpoint, `TeamStore.query()`, and `calculate_relevance()` from singular `language`/`framework` string params to plural `languages`/`frameworks` list params, matching the JSON schema and both SDKs
- Any-match semantics: a unit scores a language/framework boost if any queried value overlaps with its context
- Add multi-value regression tests at both the store and API layers

Closes #195

## Test plan

- [x] All 98 server backend tests pass (`make test-server-backend`)
- [x] Lint passes (`make lint-server-backend`)
- [x] New `test_multiple_languages_boost_any_match` verifies multi-value language ranking
- [x] New `test_multiple_frameworks_boost_any_match` verifies multi-value framework ranking
- [x] New `test_query_boosts_any_matching_language` verifies multi-value at the API layer