### PR TITLE
Drain local KUs to remote on MCP server startup

### DIFF
--- a/cli/cmd/mcp.go
+++ b/cli/cmd/mcp.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/spf13/cobra"
@@ -10,6 +12,9 @@ import (
 	"github.com/mozilla-ai/cq/cli/mcpserver"
 	cq "github.com/mozilla-ai/cq/sdk/go"
 )
+
+// drainTimeout bounds the background drain of local to remote KUs at MCP server startup.
+const drainTimeout = 30 * time.Second
 
 // NewMCPCmd returns the mcp command.
 func NewMCPCmd() *cobra.Command {
@@ -25,6 +30,14 @@ func NewMCPCmd() *cobra.Command {
 				return err
 			}
 			defer func() { _ = c.Close() }()
+
+			if c.HasRemote() {
+				go func() {
+					ctx, cancel := context.WithTimeout(context.Background(), drainTimeout)
+					defer cancel()
+					_, _ = c.Drain(ctx)
+				}()
+			}
 
 			srv := mcpserver.New(c, version.Version())
 			if err := server.ServeStdio(srv.MCPServer()); err != nil {

--- a/cli/mcpserver/server.go
+++ b/cli/mcpserver/server.go
@@ -14,6 +14,7 @@ type Client interface {
 	Confirm(ctx context.Context, ku cq.KnowledgeUnit) (cq.KnowledgeUnit, error)
 	Drain(ctx context.Context) (cq.DrainResult, error)
 	Flag(ctx context.Context, ku cq.KnowledgeUnit, reason cq.FlagReason, opts ...cq.FlagOption) (cq.KnowledgeUnit, error)
+	HasRemote() bool
 	Prompt() string
 	Propose(ctx context.Context, params cq.ProposeParams) (cq.KnowledgeUnit, error)
 	Query(ctx context.Context, params cq.QueryParams) (cq.QueryResult, error)

--- a/cli/mcpserver/server_test.go
+++ b/cli/mcpserver/server_test.go
@@ -10,13 +10,14 @@ import (
 var errMockNotImplemented = errors.New("mock method not implemented")
 
 type mockClient struct {
-	confirmFn func(ctx context.Context, ku cq.KnowledgeUnit) (cq.KnowledgeUnit, error)
-	drainFn   func(ctx context.Context) (cq.DrainResult, error)
-	flagFn    func(ctx context.Context, ku cq.KnowledgeUnit, reason cq.FlagReason, opts ...cq.FlagOption) (cq.KnowledgeUnit, error)
-	promptFn  func() string
-	proposeFn func(ctx context.Context, params cq.ProposeParams) (cq.KnowledgeUnit, error)
-	queryFn   func(ctx context.Context, params cq.QueryParams) (cq.QueryResult, error)
-	statusFn  func(ctx context.Context) (cq.StoreStats, error)
+	confirmFn   func(ctx context.Context, ku cq.KnowledgeUnit) (cq.KnowledgeUnit, error)
+	drainFn     func(ctx context.Context) (cq.DrainResult, error)
+	flagFn      func(ctx context.Context, ku cq.KnowledgeUnit, reason cq.FlagReason, opts ...cq.FlagOption) (cq.KnowledgeUnit, error)
+	hasRemote bool
+	promptFn    func() string
+	proposeFn   func(ctx context.Context, params cq.ProposeParams) (cq.KnowledgeUnit, error)
+	queryFn     func(ctx context.Context, params cq.QueryParams) (cq.QueryResult, error)
+	statusFn    func(ctx context.Context) (cq.StoreStats, error)
 }
 
 func (m *mockClient) Confirm(ctx context.Context, ku cq.KnowledgeUnit) (cq.KnowledgeUnit, error) {
@@ -46,6 +47,10 @@ func (m *mockClient) Flag(
 	}
 
 	return m.flagFn(ctx, ku, reason, opts...)
+}
+
+func (m *mockClient) HasRemote() bool {
+	return m.hasRemote
 }
 
 func (m *mockClient) Prompt() string {

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -66,6 +66,11 @@ func (c *Client) Close() error {
 	return nil
 }
 
+// HasRemote reports whether the client is configured with a remote API.
+func (c *Client) HasRemote() bool {
+	return c.remote != nil
+}
+
 // Confirm boosts the confidence of a knowledge unit.
 // Routes to local store or remote API based on the unit's tier.
 func (c *Client) Confirm(ctx context.Context, ku KnowledgeUnit) (KnowledgeUnit, error) {

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -494,6 +494,24 @@ func TestDrainNoRemote(t *testing.T) {
 	require.Contains(t, err.Error(), "no remote API configured")
 }
 
+func TestHasRemote(t *testing.T) {
+	t.Parallel()
+
+	t.Run("without remote", func(t *testing.T) {
+		t.Parallel()
+		c := newTestClient(t)
+		require.False(t, c.HasRemote())
+	})
+
+	t.Run("with remote", func(t *testing.T) {
+		t.Parallel()
+		c := newTestClientWithRemote(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		require.True(t, c.HasRemote())
+	})
+}
+
 func TestFlagRemoteUnit(t *testing.T) {
 	t.Parallel()
 	var received map[string]any


### PR DESCRIPTION
## Summary

- Restore startup drain of local KUs to remote API on MCP server start, lost when the plugin switched from Python to the Go cq binary
- Add `HasRemote()` to the Go SDK client to guard the drain call
- Drain runs in a background goroutine with a 30s timeout so it doesn't block MCP server startup

## Test plan

- [x] Verify `make test` passes (all SDK and MCP server tests green)
- [x] Verify `make lint` passes
- [ ] Start MCP server with `CQ_TEAM_ADDR` set and local KUs present; confirm they drain to remote
- [ ] Start MCP server without `CQ_TEAM_ADDR`; confirm no drain attempt and server starts normally