### PR TITLE
Add missing sync-skill step to Go SDK CI lint job

### DIFF
--- a/.github/workflows/ci-sdk-go.yaml
+++ b/.github/workflows/ci-sdk-go.yaml
@@ -34,6 +34,10 @@ jobs:
         with:
           go-version-file: sdk/go/go.mod
 
+      - name: Sync skill prompt
+        working-directory: sdk/go
+        run: make sync-skill
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:


### PR DESCRIPTION
## Summary

- The Go SDK CI lint job was missing the `make sync-skill` step that copies `SKILL.md` into `sdk/go/internal/protocol/`
- Without it, the `//go:embed skill.md` directive fails because the file is gitignored and only present after sync
- The test job and CLI workflow already had this step; only the lint job was missing it

## Test plan

- [ ] Verify the Go SDK CI lint job passes on this PR