### PR TITLE
Add tier column and merge tier counts into status

### DIFF
--- a/plugins/cq/commands/cq-status.md
+++ b/plugins/cq/commands/cq-status.md
@@ -1,11 +1,11 @@
 ---
 name: cq:status
-description: Display local cq knowledge store statistics — unit count, domains, recent additions, and confidence distribution.
+description: Display cq knowledge store statistics — tier counts (local/private/public), domains, recent additions, and confidence distribution.
 ---
 
 # /cq:status
 
-Display a summary of the local cq knowledge store.
+Display a summary of the cq knowledge store.
 
 ## Instructions
 
@@ -17,9 +17,10 @@ Display a summary of the local cq knowledge store.
 Present the results using this structure:
 
 ```
-## cq Local Store
+## cq Knowledge Store
 
-**{total_count} knowledge units**
+### Tier Counts
+local: {count} | private: {count} | public: {count}
 
 ### Domains
 {domain}: {count} | {domain}: {count} | ...
@@ -35,6 +36,8 @@ Present the results using this structure:
 ■ 0.0-0.3: {count} units
 ```
 
+The `tier_counts` field contains the tier breakdown. Display all tiers present in the response. Omit tiers with a count of 0.
+
 If the response includes `promoted_to_remote`, add this line after the total count:
 
 ```
@@ -43,7 +46,7 @@ Promoted {promoted_to_remote} knowledge units to the remote store at startup.
 
 ## Empty Store
 
-When `total_count` is 0:
+When all tier counts are 0 (or `tier_counts` is absent):
 
-- **With `promoted_to_remote`:** Show the header, total count line, and promotion line. Omit Domains, Recent Additions, and Confidence sections (there is no data to display).
-- **Without `promoted_to_remote`:** Display only: "The local cq store is empty. Knowledge units are added via `propose` or the `/cq:reflect` command."
+- **With `promoted_to_remote`:** Show the header, tier counts line, and promotion line. Omit Domains, Recent Additions, and Confidence sections (there is no data to display).
+- **Without `promoted_to_remote`:** Display only: "The cq store is empty. Knowledge units are added via `propose` or the `/cq:reflect` command."

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -370,6 +370,9 @@ func (c *Client) Query(ctx context.Context, params QueryParams) (QueryResult, er
 }
 
 // Status returns aggregated statistics about the knowledge store.
+// When a remote API is configured and reachable, tier counts include
+// both local and remote breakdowns. If the remote is unreachable,
+// only local counts are returned.
 func (c *Client) Status(ctx context.Context) (StoreStats, error) {
 	ctx, cancel := c.operationContext(ctx)
 	defer cancel()
@@ -385,6 +388,23 @@ func (c *Client) Status(ctx context.Context) (StoreStats, error) {
 
 	if err := ctx.Err(); err != nil {
 		return StoreStats{}, err
+	}
+
+	stats.TierCounts = map[Tier]int{Local: stats.TotalCount}
+
+	if c.remote != nil {
+		remote, err := c.remote.stats(ctx)
+		if err == nil {
+			for tier, count := range remote.Tiers {
+				// The remote store should never report a "local" tier, but guard
+				// against it to prevent overwriting the local count we already set.
+				if tier == Local {
+					continue
+				}
+				stats.TierCounts[tier] = count
+				stats.TotalCount += count
+			}
+		}
 	}
 
 	return stats, nil

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -579,3 +579,96 @@ func TestQueryLimitCappedAt50(t *testing.T) {
 	// Should not error; limit is silently capped.
 	require.LessOrEqual(t, len(qr.Units), 50)
 }
+
+func TestStatusLocalOnlyHasTierCounts(t *testing.T) {
+	c := newTestClient(t)
+	ctx := context.Background()
+
+	_, err := c.Propose(ctx, ProposeParams{
+		Summary: "S", Detail: "D.", Action: "A.", Domains: []string{"test"},
+	})
+	require.NoError(t, err)
+
+	stats, err := c.Status(ctx)
+	require.NoError(t, err)
+	require.Equal(t, map[Tier]int{Local: 1}, stats.TierCounts)
+}
+
+func TestStatusWithRemoteMergesTierCounts(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/stats" && r.Method == "GET" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"total_units": 3,
+				"tiers":       map[string]int{"private": 3, "public": 0},
+				"domains":     map[string]int{"api": 2},
+			})
+			return
+		}
+		// Propose unreachable — forces local fallback.
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	c := newTestClientWithRemote(t, handler)
+	ctx := context.Background()
+
+	_, err := c.Propose(ctx, ProposeParams{
+		Summary: "Local", Detail: "D.", Action: "A.", Domains: []string{"test"},
+	})
+	require.NoError(t, err)
+
+	stats, err := c.Status(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 4, stats.TotalCount)
+	require.Equal(t, 1, stats.TierCounts[Local])
+	require.Equal(t, 3, stats.TierCounts[Private])
+	require.Equal(t, 0, stats.TierCounts[Public])
+}
+
+func TestStatusRemoteUnreachableStillReturnsLocal(t *testing.T) {
+	testClearEnv(t)
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	c, err := NewClient(WithAddr("http://127.0.0.1:1"), WithLocalDBPath(dbPath), WithTimeout(1*time.Second))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	_, err = c.Propose(context.Background(), ProposeParams{
+		Summary: "S", Detail: "D.", Action: "A.", Domains: []string{"test"},
+	})
+	require.NoError(t, err)
+
+	stats, err := c.Status(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, stats.TotalCount)
+	require.Equal(t, map[Tier]int{Local: 1}, stats.TierCounts)
+}
+
+func TestStatusIgnoresLocalTierFromRemote(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/stats" && r.Method == "GET" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"total_units": 6,
+				"tiers":       map[string]int{"local": 1, "private": 4, "public": 1},
+				"domains":     map[string]int{},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	c := newTestClientWithRemote(t, handler)
+	ctx := context.Background()
+
+	_, err := c.Propose(ctx, ProposeParams{
+		Summary: "S", Detail: "D.", Action: "A.", Domains: []string{"test"},
+	})
+	require.NoError(t, err)
+
+	stats, err := c.Status(ctx)
+	require.NoError(t, err)
+	// Local count comes from the local store (1), not from the remote's "local" tier.
+	require.Equal(t, 1, stats.TierCounts[Local])
+	require.Equal(t, 4, stats.TierCounts[Private])
+	require.Equal(t, 1, stats.TierCounts[Public])
+	// Total is local (1) + private (4) + public (1) = 6. The remote's "local: 1" is excluded.
+	require.Equal(t, 6, stats.TotalCount)
+}

--- a/sdk/go/remote.go
+++ b/sdk/go/remote.go
@@ -235,6 +235,44 @@ func (r *remoteClient) query(ctx context.Context, params QueryParams) []Knowledg
 	return units
 }
 
+// remoteStatsResponse holds the server's /stats response.
+type remoteStatsResponse struct {
+	TotalUnits int          `json:"total_units"`
+	Tiers      map[Tier]int `json:"tiers"`
+	Domains    map[string]int `json:"domains"`
+}
+
+// stats fetches store statistics from the remote API.
+// Returns errUnreachable on transport/5xx errors.
+func (r *remoteClient) stats(ctx context.Context) (remoteStatsResponse, error) {
+	statsURL, err := r.url("/stats")
+	if err != nil {
+		return remoteStatsResponse{}, fmt.Errorf("%w: %w", errUnreachable, err)
+	}
+
+	resp, err := r.do(ctx, http.MethodGet, statsURL, nil)
+	if err != nil {
+		return remoteStatsResponse{}, fmt.Errorf("%w: %w", errUnreachable, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 500 {
+		return remoteStatsResponse{}, errUnreachable
+	}
+
+	if resp.StatusCode >= 400 {
+		detail, _ := io.ReadAll(resp.Body)
+		return remoteStatsResponse{}, &RemoteError{StatusCode: resp.StatusCode, Detail: string(detail)}
+	}
+
+	var result remoteStatsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return remoteStatsResponse{}, fmt.Errorf("%w: decoding response: %w", errUnreachable, err)
+	}
+
+	return result, nil
+}
+
 // url builds a full URL from the base URL and a path segment.
 func (r *remoteClient) url(path string) (string, error) {
 	return url.JoinPath(r.baseURL, path)

--- a/sdk/go/remote_test.go
+++ b/sdk/go/remote_test.go
@@ -216,3 +216,44 @@ func TestRemoteQuerySendsPluralParamNames(t *testing.T) {
 		})
 	})
 }
+
+func TestRemoteStats(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/stats", r.URL.Path)
+		require.Equal(t, "GET", r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"total_units": 5,
+			"tiers":       map[string]int{"private": 4, "public": 1},
+			"domains":     map[string]int{"api": 3, "db": 2},
+		})
+	}))
+	defer srv.Close()
+
+	rc := newRemoteClient(srv.URL, "", 5*time.Second)
+	rs, err := rc.stats(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 5, rs.TotalUnits)
+	require.Equal(t, map[Tier]int{Private: 4, Public: 1}, rs.Tiers)
+	require.Equal(t, map[string]int{"api": 3, "db": 2}, rs.Domains)
+}
+
+func TestRemoteStatsServerError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	rc := newRemoteClient(srv.URL, "", 5*time.Second)
+	_, err := rc.stats(context.Background())
+	require.ErrorIs(t, err, errUnreachable)
+}
+
+func TestRemoteStatsTransportError(t *testing.T) {
+	t.Parallel()
+	rc := newRemoteClient("http://127.0.0.1:1", "", 1*time.Second)
+	_, err := rc.stats(context.Background())
+	require.ErrorIs(t, err, errUnreachable)
+}

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -101,6 +101,7 @@ type StoreStats struct {
 	DomainCounts           map[string]int  `json:"domain_counts"`
 	Recent                 []KnowledgeUnit `json:"recent"`
 	ConfidenceDistribution map[string]int  `json:"confidence_distribution"`
+	TierCounts             map[Tier]int    `json:"tier_counts"`
 }
 
 type Warnings []error

--- a/sdk/python/src/cq/client.py
+++ b/sdk/python/src/cq/client.py
@@ -4,7 +4,7 @@ Handles remote mode (HTTP calls to a cq API) and local mode
 (SQLite at $XDG_DATA_HOME/cq/local.db), with fallback between them.
 """
 
-import logging
+import contextlib
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -23,8 +23,6 @@ from .models import (
 )
 from .scoring import apply_confirmation, apply_flag
 from .store import LocalStore, StoreStats
-
-logger = logging.getLogger(__name__)
 
 _DEFAULT_TIMEOUT = 5.0
 
@@ -209,7 +207,6 @@ class Client:
             if result is not None:
                 return result
             # Remote unreachable — fall back to local storage.
-            logger.info("Remote unreachable; storing unit %s locally as fallback.", unit.id)
 
         self._store.insert(unit)
         return unit
@@ -235,10 +232,8 @@ class Client:
             confirmed = apply_confirmation(unit)
             self._store.update(confirmed)
             if self._http is not None:
-                try:
+                with contextlib.suppress(RemoteError):
                     self._remote_confirm(unit_id)
-                except RemoteError:
-                    logger.debug("Remote rejected confirm for local unit %s", unit_id)
             return confirmed
 
         if self._http is None:
@@ -269,10 +264,8 @@ class Client:
             flagged = apply_flag(unit, reason)
             self._store.update(flagged)
             if self._http is not None:
-                try:
+                with contextlib.suppress(RemoteError):
                     self._remote_flag(unit_id, reason)
-                except RemoteError:
-                    logger.debug("Remote rejected flag for local unit %s", unit_id)
             return flagged
 
         if self._http is None:
@@ -283,8 +276,27 @@ class Client:
         raise KeyError(f"Remote unreachable; cannot flag unit: {unit_id}")
 
     def status(self) -> StoreStats:
-        """Return local store statistics."""
-        return self._store.stats()
+        """Return knowledge store statistics with tier counts.
+
+        When a remote API is configured and reachable, tier counts include
+        both local and remote breakdowns. If the remote is unreachable,
+        only local counts are returned.
+        """
+        stats = self._store.stats()
+        stats.tier_counts = {Tier.LOCAL: stats.total_count}
+
+        if self._http is not None:
+            remote = self._remote_stats()
+            if remote is not None:
+                for tier, count in remote.get("tiers", {}).items():
+                    # The remote store should never report a "local" tier, but guard
+                    # against it to prevent overwriting the local count we already set.
+                    if tier == Tier.LOCAL:
+                        continue
+                    stats.tier_counts[tier] = count
+                    stats.total_count += count
+
+        return stats
 
     @staticmethod
     def prompt() -> str:
@@ -322,6 +334,20 @@ class Client:
         return DrainResult(pushed=pushed, warnings=warnings)
 
     # -- Remote HTTP helpers (graceful degradation) --
+
+    def _remote_stats(self) -> dict | None:
+        """Fetch store statistics from the remote API.
+
+        Returns:
+            The stats dict on success, None on transport error.
+        """
+        assert self._http is not None
+        try:
+            resp = self._http.get("/stats")
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPError:
+            return None
 
     def _remote_query(
         self,
@@ -374,7 +400,6 @@ class Client:
                 detail=exc.response.text,
             ) from exc
         except httpx.HTTPError:
-            logger.debug("Remote propose unreachable", exc_info=True)
             return None
         try:
             data = resp.json()
@@ -382,7 +407,6 @@ class Client:
             return KnowledgeUnit.model_validate(unit_data)
         except (ValueError, ValidationError):
             # Server accepted but response is not a parseable KU.
-            logger.debug("Remote propose accepted but response not parseable; using local unit.")
             return unit
 
     def _remote_confirm(self, unit_id: str) -> KnowledgeUnit | None:
@@ -405,7 +429,6 @@ class Client:
                 detail=exc.response.text,
             ) from exc
         except httpx.HTTPError:
-            logger.debug("Remote confirm failed", exc_info=True)
             return None
         try:
             data = resp.json()
@@ -440,7 +463,6 @@ class Client:
                 detail=exc.response.text,
             ) from exc
         except httpx.HTTPError:
-            logger.debug("Remote flag failed", exc_info=True)
             return None
         try:
             data = resp.json()

--- a/sdk/python/src/cq/store.py
+++ b/sdk/python/src/cq/store.py
@@ -49,12 +49,13 @@ def _default_db_path() -> Path:
 
 
 class StoreStats(BaseModel):
-    """Aggregated statistics for the local knowledge store."""
+    """Aggregated statistics for the knowledge store."""
 
     total_count: int
     domain_counts: dict[str, int] = Field(default_factory=dict)
     recent: list[KnowledgeUnit] = Field(default_factory=list)
     confidence_distribution: dict[str, int] = Field(default_factory=dict)
+    tier_counts: dict[str, int] = Field(default_factory=dict)
 
 
 _SCHEMA_SQL = """

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -79,6 +79,16 @@ class TestLocalOnlyMode:
         assert stats.total_count == 1
         assert "api" in stats.domain_counts
 
+    def test_status_local_only_has_tier_counts(self, client: Client):
+        client.propose(
+            summary="Test",
+            detail="Detail.",
+            action="Action.",
+            domains=["api"],
+        )
+        stats = client.status()
+        assert stats.tier_counts == {"local": 1}
+
     def test_drain_raises_without_remote(self, client: Client):
         with pytest.raises(RuntimeError, match="No remote API configured"):
             client.drain()
@@ -528,6 +538,58 @@ class TestRemoteIntegration:
 
         confirmed = c.confirm(unit.id)
         assert confirmed.evidence.confidence == pytest.approx(0.6)
+        c.close()
+
+    def test_status_merges_remote_tier_counts(self, tmp_path: Path, httpx_mock):
+        """status() merges local and remote tier counts."""
+        httpx_mock.add_response(
+            url=httpx.URL("http://test-remote/stats"),
+            json={"total_units": 3, "tiers": {"private": 3, "public": 0}, "domains": {}},
+        )
+
+        local_client = Client(local_db_path=tmp_path / "test.db")
+        local_client.propose(summary="S", detail="D", action="A", domains=["api"])
+        local_client.close()
+
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        stats = c.status()
+        assert stats.tier_counts["local"] == 1
+        assert stats.tier_counts["private"] == 3
+        assert stats.tier_counts["public"] == 0
+        assert stats.total_count == 4
+        c.close()
+
+    def test_status_remote_unreachable_returns_local_only(self, tmp_path: Path, httpx_mock):
+        """status() returns local-only tier counts when remote is unreachable."""
+        httpx_mock.add_exception(httpx.ConnectError("Connection refused"))
+
+        local_client = Client(local_db_path=tmp_path / "test.db")
+        local_client.propose(summary="S", detail="D", action="A", domains=["api"])
+        local_client.close()
+
+        c = Client(addr="http://unreachable", local_db_path=tmp_path / "test.db")
+        stats = c.status()
+        assert stats.total_count == 1
+        assert stats.tier_counts == {"local": 1}
+        c.close()
+
+    def test_status_ignores_local_tier_from_remote(self, tmp_path: Path, httpx_mock):
+        """status() ignores 'local' tier in remote response to prevent double-counting."""
+        httpx_mock.add_response(
+            url=httpx.URL("http://test-remote/stats"),
+            json={"total_units": 6, "tiers": {"local": 1, "private": 4, "public": 1}, "domains": {}},
+        )
+
+        local_client = Client(local_db_path=tmp_path / "test.db")
+        local_client.propose(summary="S", detail="D", action="A", domains=["api"])
+        local_client.close()
+
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        stats = c.status()
+        assert stats.tier_counts["local"] == 1
+        assert stats.tier_counts["private"] == 4
+        assert stats.tier_counts["public"] == 1
+        assert stats.total_count == 6
         c.close()
 
     def test_flag_local_ignores_remote_rejection(self, tmp_path: Path, httpx_mock):

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -47,6 +47,7 @@ class StatsResponse(BaseModel):
     """Response body for store statistics."""
 
     total_units: int
+    tiers: dict[str, int]
     domains: dict[str, int]
 
 
@@ -147,6 +148,7 @@ def stats() -> StatsResponse:
     store = _get_store()
     return StatsResponse(
         total_units=store.count(),
+        tiers=store.counts_by_tier(),
         domains=store.domain_counts(),
     )
 

--- a/server/backend/src/cq_server/store.py
+++ b/server/backend/src/cq_server/store.py
@@ -130,8 +130,8 @@ class RemoteStore:
         )
         with self._lock, self._conn:
             self._conn.execute(
-                "INSERT INTO knowledge_units (id, data, created_at) VALUES (?, ?, ?)",
-                (unit.id, data, created_at),
+                "INSERT INTO knowledge_units (id, data, created_at, tier) VALUES (?, ?, ?, ?)",
+                (unit.id, data, created_at, unit.tier.value),
             )
             self._conn.executemany(
                 "INSERT INTO knowledge_unit_domains (unit_id, domain) VALUES (?, ?)",
@@ -240,8 +240,8 @@ class RemoteStore:
         data = unit.model_dump_json()
         with self._lock, self._conn:
             cursor = self._conn.execute(
-                "UPDATE knowledge_units SET data = ? WHERE id = ?",
-                (data, unit.id),
+                "UPDATE knowledge_units SET data = ?, tier = ? WHERE id = ?",
+                (data, unit.tier.value, unit.id),
             )
             if cursor.rowcount == 0:
                 raise KeyError(f"Knowledge unit not found: {unit.id}")
@@ -380,6 +380,15 @@ class RemoteStore:
         self._check_open()
         with self._lock:
             rows = self._conn.execute("SELECT status, COUNT(*) FROM knowledge_units GROUP BY status").fetchall()
+        return {row[0]: row[1] for row in rows}
+
+    def counts_by_tier(self) -> dict[str, int]:
+        """Return approved KU counts grouped by tier."""
+        self._check_open()
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT tier, COUNT(*) FROM knowledge_units WHERE status = 'approved' GROUP BY tier"
+            ).fetchall()
         return {row[0]: row[1] for row in rows}
 
     def list_units(

--- a/server/backend/src/cq_server/tables.py
+++ b/server/backend/src/cq_server/tables.py
@@ -7,6 +7,7 @@ _REVIEW_COLUMN_STATEMENTS = [
     "ALTER TABLE knowledge_units ADD COLUMN reviewed_by TEXT",
     "ALTER TABLE knowledge_units ADD COLUMN reviewed_at TEXT",
     "ALTER TABLE knowledge_units ADD COLUMN created_at TEXT",
+    "ALTER TABLE knowledge_units ADD COLUMN tier TEXT NOT NULL DEFAULT 'private'",
 ]
 
 USERS_TABLE_SQL = """

--- a/server/backend/tests/test_app.py
+++ b/server/backend/tests/test_app.py
@@ -211,6 +211,7 @@ class TestStats:
         assert resp.status_code == 200
         body = resp.json()
         assert body["total_units"] == 0
+        assert body["tiers"] == {}
         assert body["domains"] == {}
 
     def test_stats_after_inserts(self, client: TestClient) -> None:
@@ -225,6 +226,7 @@ class TestStats:
         assert resp.status_code == 200
         body = resp.json()
         assert body["total_units"] == 2
+        assert body["tiers"] == {"private": 2}
         assert body["domains"]["api"] == 2
         assert body["domains"]["auth"] == 1
         assert body["domains"]["payments"] == 1

--- a/server/backend/tests/test_store.py
+++ b/server/backend/tests/test_store.py
@@ -224,6 +224,75 @@ class TestStats:
         assert counts["auth"] == 1
 
 
+class TestTierColumn:
+    def test_tier_column_exists_after_migration(self, store: RemoteStore) -> None:
+        """The tier column should exist on the knowledge_units table."""
+        cursor = store._conn.execute("PRAGMA table_info(knowledge_units)")
+        columns = {row[1] for row in cursor.fetchall()}
+        assert "tier" in columns
+
+    def test_tier_column_defaults_to_private_for_migration(self, store: RemoteStore) -> None:
+        """Pre-existing rows without an explicit tier get 'private' from the column default."""
+        store._conn.execute(
+            "INSERT INTO knowledge_units (id, data, created_at) VALUES (?, ?, ?)",
+            ("ku_00000000000000000000000000000001", "{}", "2026-01-01T00:00:00Z"),
+        )
+        store._conn.commit()
+        row = store._conn.execute(
+            "SELECT tier FROM knowledge_units WHERE id = ?",
+            ("ku_00000000000000000000000000000001",),
+        ).fetchone()
+        assert row[0] == "private"
+
+    def test_insert_populates_tier_from_unit(self, store: RemoteStore) -> None:
+        """Insert should write the unit's tier value to the tier column."""
+        unit = _make_unit(tier=Tier.PRIVATE)
+        store.insert(unit)
+        row = store._conn.execute(
+            "SELECT tier FROM knowledge_units WHERE id = ?", (unit.id,)
+        ).fetchone()
+        assert row[0] == "private"
+
+    def test_update_syncs_tier_column(self, store: RemoteStore) -> None:
+        """Update should keep the tier column in sync with the JSON blob."""
+        unit = _make_unit(tier=Tier.PRIVATE)
+        store.insert(unit)
+        updated = unit.model_copy(update={"tier": Tier.PUBLIC})
+        store.update(updated)
+        row = store._conn.execute(
+            "SELECT tier FROM knowledge_units WHERE id = ?", (unit.id,)
+        ).fetchone()
+        assert row[0] == "public"
+
+    def test_counts_by_tier_empty(self, store: RemoteStore) -> None:
+        """Empty store returns empty dict."""
+        assert store.counts_by_tier() == {}
+
+    def test_counts_by_tier_approved_only(self, store: RemoteStore) -> None:
+        """Only approved units are counted."""
+        u1 = _make_unit(domains=["a"], tier=Tier.PRIVATE)
+        u2 = _make_unit(domains=["b"], tier=Tier.PRIVATE)
+        u3 = _make_unit(domains=["c"], tier=Tier.PRIVATE)
+        store.insert(u1)
+        store.insert(u2)
+        store.insert(u3)
+        store.set_review_status(u1.id, "approved", "reviewer")
+        store.set_review_status(u2.id, "approved", "reviewer")
+        counts = store.counts_by_tier()
+        assert counts == {"private": 2}
+
+    def test_counts_by_tier_groups_correctly(self, store: RemoteStore) -> None:
+        """Counts are grouped by tier value."""
+        u1 = _make_unit(domains=["a"], tier=Tier.PRIVATE)
+        u2 = _make_unit(domains=["b"], tier=Tier.PUBLIC)
+        store.insert(u1)
+        store.insert(u2)
+        store.set_review_status(u1.id, "approved", "reviewer")
+        store.set_review_status(u2.id, "approved", "reviewer")
+        counts = store.counts_by_tier()
+        assert counts == {"private": 1, "public": 1}
+
+
 class TestReviewStatus:
     def test_inserted_unit_has_pending_status(self, store: RemoteStore) -> None:
         unit = _make_unit()


### PR DESCRIPTION
## Summary
- Add `tier` column to server's knowledge_units table with migration
  (default 'private'), populate on insert/update, add `counts_by_tier()`
  and surface in `GET /stats` response
- Go SDK: `remote.stats()` calls server, `Client.Status()` merges local
  + remote tier counts into `StoreStats.TierCounts` (typed `map[Tier]int`)
- Python SDK: same merge in `Client.status()` with `_remote_stats()` helper
- Update cq-status skill to display tier counts
- Remove internal logging from Python SDK client

## Test plan
- [ ] Server: migration, insert/update, counts_by_tier, /stats endpoint
- [ ] Go SDK: remote stats, merged status (local-only, merged, unreachable, guard)
- [ ] Python SDK: merged status (local-only, merged, unreachable, guard)
- [ ] Linters pass (ruff, golangci-lint)