### PR TITLE
Bump plugin to 0.6.0 and CLI version pin to 0.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "cq",
       "source": "./plugins/cq",
       "description": "Shared knowledge commons for AI agents; find, share, and confirm collective knowledge to stop rediscovering the same failures.",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "category": "knowledge",
       "tags": ["knowledge-sharing", "agent-learning", "agent-commons","mcp", "pitfall-avoidance", "team-knowledge", "api-quirks"]
     }

--- a/plugins/cq/.claude-plugin/plugin.json
+++ b/plugins/cq/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cq",
-  "version": "0.5.0",
-  "cliVersion": "0.1.0",
+  "version": "0.6.0",
+  "cliVersion": "0.2.0",
   "description": "Shared knowledge commons for AI agents; find, share, and confirm collective knowledge to stop rediscovering the same failures.",
   "skills": "./skills/",
   "commands": "./commands/",

--- a/plugins/cq/pyproject.toml
+++ b/plugins/cq/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cq-plugin"
-version = "0.5.0"
+version = "0.6.0"
 description = "cq Plugin for coding agents (e.g. Claude Code, OpenCode) - shared agent knowledge commons"
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## Summary

- Bump plugin version from 0.5.0 to 0.6.0 in plugin.json, pyproject.toml, and marketplace.json
- Bump CLI version pin from 0.1.0 to 0.2.0 in plugin.json (bootstrap script resolves this dynamically)

## Test plan

- [ ] Verify plugin installs and bootstrap resolves CLI v0.2.0
- [ ] Verify marketplace listing shows v0.6.0