### PR TITLE
Fix stale plugin lockfile and enforce uv lockfile freshness

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,23 @@ repos:
         types: [python]
         files: ^server/backend/
 
-  - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.10.7
+  - repo: local
     hooks:
-      - id: uv-lock
+      - id: uv-lock-check-plugin
+        name: uv lock --check (plugins/cq)
+        entry: uv lock --check --directory plugins/cq
+        language: system
+        pass_filenames: false
+        files: ^plugins/cq/(pyproject\.toml|uv\.lock|uv\.toml)$
+      - id: uv-lock-check-sdk-python
+        name: uv lock --check (sdk/python)
+        entry: uv lock --check --directory sdk/python
+        language: system
+        pass_filenames: false
+        files: ^sdk/python/(pyproject\.toml|uv\.lock|uv\.toml)$
+      - id: uv-lock-check-server-backend
+        name: uv lock --check (server/backend)
+        entry: uv lock --check --directory server/backend
+        language: system
+        pass_filenames: false
+        files: ^server/backend/(pyproject\.toml|uv\.lock|uv\.toml)$

--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ lint-cli:
 
 .PHONY: lint-plugin
 lint-plugin:
-	cd plugins/cq && uv run pre-commit run --files scripts/*.py
+	cd plugins/cq && uv run --locked pre-commit run --files scripts/*.py pyproject.toml uv.lock
 
 .PHONY: lint-sdk-go
 lint-sdk-go:
@@ -177,11 +177,11 @@ lint-sdk-go:
 
 .PHONY: lint-sdk-python
 lint-sdk-python:
-	cd sdk/python && uv run pre-commit run --files src/**/*.py
+	cd sdk/python && uv run --locked pre-commit run --files src/**/*.py pyproject.toml uv.lock
 
 .PHONY: lint-server-backend
 lint-server-backend:
-	cd server/backend && uv run pre-commit run --files src/**/*.py
+	cd server/backend && uv run --locked pre-commit run --files src/**/*.py pyproject.toml uv.lock
 
 .PHONY: lint-server-frontend
 lint-server-frontend:

--- a/plugins/cq/uv.lock
+++ b/plugins/cq/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "cq-plugin"
-version = "0.5.0"
+version = "0.6.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/sdk/python/.pre-commit-config.yaml
+++ b/sdk/python/.pre-commit-config.yaml
@@ -29,7 +29,11 @@ repos:
       - id: detect-secrets
         exclude: uv\.lock$
 
-  - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.10.7
+  - repo: local
     hooks:
-      - id: uv-lock
+      - id: uv-lock-check-sdk-python
+        name: uv lock --check (sdk/python)
+        entry: uv lock --check --directory sdk/python
+        language: system
+        pass_filenames: false
+        files: ^sdk/python/(pyproject\.toml|uv\.lock|uv\.toml)$


### PR DESCRIPTION
## Summary
- Regenerate `plugins/cq/uv.lock` to match the 0.6.0 version that #239 bumped in `pyproject.toml` but did not relock.
- Add `uv run --locked` to `lint-plugin`, `lint-sdk-python`, and `lint-server-backend` so CI fails fast on stale lockfiles in any of the three Python sub-projects.
- Replace the inert upstream `uv-lock` hook (in both root and `sdk/python` configs) with per-subproject local pre-commit hooks that run `uv lock --check --directory <subdir>` so `git commit` catches drift too.

## Why two layers?
`uv run` silently regenerates a stale lockfile before invoking the wrapped command. The Makefile targets use `uv run pre-commit run ...`, so any pre-commit hook that tried to check the lockfile would always see a freshly-regenerated file in CI — drift would never surface. `uv run --locked` flips that: uv aborts with a clear error before regenerating. The pre-commit hooks add commit-time coverage for the path where `pre-commit` is invoked directly (e.g. via `pre-commit install`), which doesn't go through `uv run`.

## Why local pre-commit hooks (not the upstream `astral-sh/uv-pre-commit` `uv-lock` hook)?
- The upstream hook's default `files: ^(uv\.lock|pyproject\.toml|uv\.toml)$` is anchored to the repo root. cq has no root `pyproject.toml` (three independent sub-projects, not a uv workspace), so the existing hook in both `.pre-commit-config.yaml` and `sdk/python/.pre-commit-config.yaml` never matched anything.
- A `local` hook with `entry: uv lock --check --directory <subdir>` mirrors cq's existing `ty-check-*` pattern, gives explicit control, and works correctly when invoked directly by pre-commit (not through `uv run`).

## Test plan
- [x] `make lint-plugin` / `make lint-sdk-python` / `make lint-server-backend` all pass with the regenerated lockfile.
- [x] Negative test (each sub-project): introduce drift and confirm `make lint-*` aborts via `uv run --locked` with a clear error and the lockfile is left untouched.
- [x] Negative test (commit-time path): invoke `pre-commit run uv-lock-check-plugin` directly with stale lockfile — confirms hook fails with `uv lock --check` error and does not modify the file.