### PR TITLE
Replace exact cli_version check with cli_min_version >= comparison

### DIFF
--- a/plugins/cq/scripts/bootstrap.json
+++ b/plugins/cq/scripts/bootstrap.json
@@ -1,3 +1,3 @@
 {
-  "cli_version": "0.2.1"
+  "cli_min_version": "0.2.1"
 }

--- a/plugins/cq/scripts/bootstrap.py
+++ b/plugins/cq/scripts/bootstrap.py
@@ -22,15 +22,15 @@ import cq_binary
 def main() -> None:
     """Ensure the cq binary is cached, then exec into the MCP server."""
     metadata_path = Path(__file__).resolve().with_name("bootstrap.json")
-    required_version = cq_binary.load_min_version(metadata_path)
-    if not required_version:
+    min_version = cq_binary.load_min_version(metadata_path)
+    if not min_version:
         print("Error: minimum CLI version not set in bootstrap metadata", file=sys.stderr)
         sys.exit(1)
 
     bin_dir = cq_binary.shared_bin_dir()
     binary = bin_dir / cq_binary.cq_binary_name()
 
-    cq_binary.ensure_binary(binary, required_version, bin_dir)
+    cq_binary.ensure_binary(binary, min_version, bin_dir)
 
     os.execvp(str(binary), [str(binary), "mcp"])
 

--- a/plugins/cq/scripts/bootstrap.py
+++ b/plugins/cq/scripts/bootstrap.py
@@ -22,9 +22,9 @@ import cq_binary
 def main() -> None:
     """Ensure the cq binary is cached, then exec into the MCP server."""
     metadata_path = Path(__file__).resolve().with_name("bootstrap.json")
-    required_version = cq_binary.load_required_version(metadata_path)
+    required_version = cq_binary.load_min_version(metadata_path)
     if not required_version:
-        print("Error: required CLI version not set in bootstrap metadata", file=sys.stderr)
+        print("Error: minimum CLI version not set in bootstrap metadata", file=sys.stderr)
         sys.exit(1)
 
     bin_dir = cq_binary.shared_bin_dir()

--- a/plugins/cq/scripts/cq_binary.py
+++ b/plugins/cq/scripts/cq_binary.py
@@ -27,11 +27,6 @@ from pathlib import Path
 REPO = "mozilla-ai/cq"
 
 
-def check_version(binary: Path, required: str) -> bool:
-    """Check whether the binary reports the required version."""
-    return parse_version(binary) == required
-
-
 def cq_binary_name() -> str:
     """Return the cq binary filename for the current platform."""
     return "cq.exe" if platform.system() == "Windows" else "cq"
@@ -114,10 +109,10 @@ def download(version: str, system: str, bin_dir: Path, binary: Path) -> None:
         tmp_path.unlink(missing_ok=True)
 
 
-def ensure_binary(binary: Path, required_version: str, bin_dir: Path) -> None:
+def ensure_binary(binary: Path, min_version: str, bin_dir: Path) -> None:
     """Resolve the cq binary, preferring a cached copy over a fresh download."""
-    # Fast path: cached binary (file or symlink) already at the right version.
-    if binary.is_file() and check_version(binary, required_version):
+    # Fast path: cached binary (file or symlink) already meets the minimum.
+    if binary.is_file() and meets_min_version(binary, min_version):
         return
 
     # Discard any stale binary or broken symlink before resolving fresh.
@@ -127,13 +122,14 @@ def ensure_binary(binary: Path, required_version: str, bin_dir: Path) -> None:
     bin_dir.mkdir(parents=True, exist_ok=True)
 
     system_cq = shutil.which("cq")
-    if system_cq and check_version(Path(system_cq), required_version):
+    if system_cq and meets_min_version(Path(system_cq), min_version):
         link_or_copy(Path(system_cq), binary)
-        print(f"cq: using system v{required_version} from {system_cq}", file=sys.stderr)
+        actual = parse_version(Path(system_cq))
+        print(f"cq: using system v{actual} from {system_cq}", file=sys.stderr)
         return
 
-    download(required_version, platform.system(), bin_dir, binary)
-    print(f"cq: downloaded v{required_version} to {binary}", file=sys.stderr)
+    download(min_version, platform.system(), bin_dir, binary)
+    print(f"cq: downloaded v{min_version} to {binary}", file=sys.stderr)
 
 
 def link_or_copy(source: Path, dest: Path) -> None:
@@ -145,13 +141,30 @@ def link_or_copy(source: Path, dest: Path) -> None:
         dest.symlink_to(source)
 
 
-def load_required_version(metadata_path: Path) -> str:
-    """Return the required cq CLI version from bootstrap metadata."""
+def load_min_version(metadata_path: Path) -> str:
+    """Return the minimum required cq CLI version from bootstrap metadata."""
     if not metadata_path.exists():
         return ""
     with metadata_path.open() as f:
         config = json.load(f)
-    return config.get("cli_version", "")
+    return config.get("cli_min_version", "")
+
+
+def meets_min_version(binary: Path, min_version: str) -> bool:
+    """Check whether the binary version is at least min_version."""
+    actual = parse_semver(parse_version(binary))
+    required = parse_semver(min_version)
+    if not actual or not required:
+        return False
+    return actual >= required
+
+
+def parse_semver(version: str) -> tuple[int, ...]:
+    """Split a semver string into a comparable integer tuple."""
+    try:
+        return tuple(int(p) for p in version.split("."))
+    except (ValueError, AttributeError):
+        return ()
 
 
 def parse_version(binary: Path) -> str:

--- a/plugins/cq/tests/test_bootstrap.py
+++ b/plugins/cq/tests/test_bootstrap.py
@@ -33,7 +33,7 @@ def _load_bootstrap() -> ModuleType:
 
 def test_main_loads_version_ensures_binary_and_replaces_process(monkeypatch, tmp_path):
     metadata = tmp_path / "bootstrap.json"
-    metadata.write_text('{"cli_version": "0.2.0"}\n')
+    metadata.write_text('{"cli_min_version": "0.2.0"}\n')
 
     bootstrap = _load_bootstrap()
     calls: list[tuple[str, tuple]] = []
@@ -81,4 +81,4 @@ def test_main_exits_when_metadata_missing_version(monkeypatch, tmp_path, capsys)
         bootstrap.main()
 
     assert exc_info.value.code == 1
-    assert "required CLI version not set" in capsys.readouterr().err
+    assert "minimum CLI version not set" in capsys.readouterr().err

--- a/plugins/cq/tests/test_cq_binary.py
+++ b/plugins/cq/tests/test_cq_binary.py
@@ -87,31 +87,69 @@ def test_cq_binary_name_on_unix(cq_binary, monkeypatch):
     assert cq_binary.cq_binary_name() == "cq"
 
 
-def test_load_required_version_reads_cli_version(cq_binary, tmp_path):
+def test_load_min_version_reads_cli_min_version(cq_binary, tmp_path):
     metadata = tmp_path / "bootstrap.json"
-    metadata.write_text('{"cli_version": "9.9.9"}\n')
-    assert cq_binary.load_required_version(metadata) == "9.9.9"
+    metadata.write_text('{"cli_min_version": "9.9.9"}\n')
+    assert cq_binary.load_min_version(metadata) == "9.9.9"
 
 
-def test_load_required_version_returns_empty_when_missing_file(cq_binary, tmp_path):
+def test_load_min_version_returns_empty_when_missing_file(cq_binary, tmp_path):
     metadata = tmp_path / "bootstrap.json"
-    assert cq_binary.load_required_version(metadata) == ""
+    assert cq_binary.load_min_version(metadata) == ""
 
 
-def test_load_required_version_returns_empty_when_missing_key(cq_binary, tmp_path):
+def test_load_min_version_returns_empty_when_missing_key(cq_binary, tmp_path):
     metadata = tmp_path / "bootstrap.json"
     metadata.write_text('{"other": "value"}\n')
-    assert cq_binary.load_required_version(metadata) == ""
+    assert cq_binary.load_min_version(metadata) == ""
 
 
-def test_check_version_returns_true_on_match(cq_binary, monkeypatch):
+def test_load_min_version_ignores_old_cli_version_key(cq_binary, tmp_path):
+    metadata = tmp_path / "bootstrap.json"
+    metadata.write_text('{"cli_version": "1.0.0"}\n')
+    assert cq_binary.load_min_version(metadata) == ""
+
+
+def test_meets_min_version_returns_true_on_exact_match(cq_binary, monkeypatch):
     monkeypatch.setattr(cq_binary, "parse_version", lambda _binary: "1.2.3")
-    assert cq_binary.check_version(Path("/fake/cq"), "1.2.3") is True
+    assert cq_binary.meets_min_version(Path("/fake/cq"), "1.2.3") is True
 
 
-def test_check_version_returns_false_on_mismatch(cq_binary, monkeypatch):
+def test_meets_min_version_returns_true_when_newer(cq_binary, monkeypatch):
+    monkeypatch.setattr(cq_binary, "parse_version", lambda _binary: "1.3.0")
+    assert cq_binary.meets_min_version(Path("/fake/cq"), "1.2.3") is True
+
+
+def test_meets_min_version_returns_true_when_newer_patch(cq_binary, monkeypatch):
+    monkeypatch.setattr(cq_binary, "parse_version", lambda _binary: "0.2.5")
+    assert cq_binary.meets_min_version(Path("/fake/cq"), "0.2.1") is True
+
+
+def test_meets_min_version_returns_false_when_older(cq_binary, monkeypatch):
     monkeypatch.setattr(cq_binary, "parse_version", lambda _binary: "1.2.3")
-    assert cq_binary.check_version(Path("/fake/cq"), "9.9.9") is False
+    assert cq_binary.meets_min_version(Path("/fake/cq"), "9.9.9") is False
+
+
+def test_meets_min_version_returns_false_when_older_minor(cq_binary, monkeypatch):
+    monkeypatch.setattr(cq_binary, "parse_version", lambda _binary: "0.1.9")
+    assert cq_binary.meets_min_version(Path("/fake/cq"), "0.2.1") is False
+
+
+def test_meets_min_version_returns_false_on_empty_version(cq_binary, monkeypatch):
+    monkeypatch.setattr(cq_binary, "parse_version", lambda _binary: "")
+    assert cq_binary.meets_min_version(Path("/fake/cq"), "1.2.3") is False
+
+
+def test_parse_semver_splits_valid_version(cq_binary):
+    assert cq_binary.parse_semver("1.2.3") == (1, 2, 3)
+
+
+def test_parse_semver_returns_empty_tuple_for_empty_string(cq_binary):
+    assert cq_binary.parse_semver("") == ()
+
+
+def test_parse_semver_returns_empty_tuple_for_invalid_input(cq_binary):
+    assert cq_binary.parse_semver("abc") == ()
 
 
 def test_ensure_binary_fast_path_leaves_existing_binary_alone(cq_binary, monkeypatch, tmp_path):
@@ -120,7 +158,7 @@ def test_ensure_binary_fast_path_leaves_existing_binary_alone(cq_binary, monkeyp
     binary = bin_dir / "cq"
     binary.write_text("existing")
 
-    monkeypatch.setattr(cq_binary, "check_version", lambda _b, _v: True)
+    monkeypatch.setattr(cq_binary, "meets_min_version", lambda _b, _v: True)
 
     def _download_should_not_run(*_args, **_kwargs):
         raise AssertionError("download should not run on fast path")
@@ -142,7 +180,7 @@ def test_ensure_binary_reuses_valid_symlink(cq_binary, monkeypatch, tmp_path):
     binary = bin_dir / "cq"
     binary.symlink_to(system_binary)
 
-    monkeypatch.setattr(cq_binary, "check_version", lambda _b, _v: True)
+    monkeypatch.setattr(cq_binary, "meets_min_version", lambda _b, _v: True)
     monkeypatch.setattr(cq_binary.shutil, "which", lambda _name: None)
 
     def _download_should_not_run(*_args, **_kwargs):
@@ -164,7 +202,8 @@ def test_ensure_binary_falls_back_to_system_cq(cq_binary, monkeypatch, tmp_path)
     system_binary = tmp_path / "usr-local-bin-cq"
     system_binary.write_text("real")
 
-    monkeypatch.setattr(cq_binary, "check_version", lambda _b, _v: True)
+    monkeypatch.setattr(cq_binary, "meets_min_version", lambda _b, _v: True)
+    monkeypatch.setattr(cq_binary, "parse_version", lambda _b: "0.2.0")
     monkeypatch.setattr(cq_binary.shutil, "which", lambda _name: str(system_binary))
 
     def _download_should_not_run(*_args, **_kwargs):
@@ -182,7 +221,7 @@ def test_ensure_binary_downloads_when_no_system_cq(cq_binary, monkeypatch, tmp_p
     bin_dir = tmp_path / "bin"
     binary = bin_dir / "cq"
 
-    monkeypatch.setattr(cq_binary, "check_version", lambda _b, _v: False)
+    monkeypatch.setattr(cq_binary, "meets_min_version", lambda _b, _v: False)
     monkeypatch.setattr(cq_binary.shutil, "which", lambda _name: None)
     monkeypatch.setattr(cq_binary.platform, "system", lambda: "Linux")
 
@@ -217,7 +256,8 @@ def test_ensure_binary_unlinks_broken_symlink_before_resolving(cq_binary, monkey
     real_cq = tmp_path / "real-cq"
     real_cq.write_text("real")
 
-    monkeypatch.setattr(cq_binary, "check_version", lambda _b, _v: True)
+    monkeypatch.setattr(cq_binary, "meets_min_version", lambda _b, _v: True)
+    monkeypatch.setattr(cq_binary, "parse_version", lambda _b: "0.2.0")
     monkeypatch.setattr(cq_binary.shutil, "which", lambda _name: str(real_cq))
     monkeypatch.setattr(cq_binary, "download", lambda *_a, **_k: None)
 

--- a/scripts/install/src/cq_install/binary.py
+++ b/scripts/install/src/cq_install/binary.py
@@ -41,11 +41,13 @@ def ensure_cq_binary(plugin_root: Path, *, dry_run: bool = False) -> list[Change
     binary = bin_dir / module.cq_binary_name()
 
     already_valid = binary.is_file() and module.meets_min_version(binary, min_version)
-    detail_cached = f"cq v{min_version}"
+
+    if already_valid:
+        actual = module.parse_version(binary)
+        detail = f"cq v{actual}"
+        return [ChangeResult(action=Action.UNCHANGED, path=binary, detail=detail)]
 
     if dry_run:
-        if already_valid:
-            return [ChangeResult(action=Action.UNCHANGED, path=binary, detail=detail_cached)]
         return [
             ChangeResult(
                 action=Action.SKIPPED,
@@ -54,11 +56,8 @@ def ensure_cq_binary(plugin_root: Path, *, dry_run: bool = False) -> list[Change
             )
         ]
 
-    if already_valid:
-        return [ChangeResult(action=Action.UNCHANGED, path=binary, detail=detail_cached)]
-
     module.ensure_binary(binary, min_version, bin_dir)
-    return [ChangeResult(action=Action.CREATED, path=binary, detail=detail_cached)]
+    return [ChangeResult(action=Action.CREATED, path=binary, detail=f"cq v{min_version}")]
 
 
 def _load_cq_binary(plugin_root: Path) -> ModuleType:

--- a/scripts/install/src/cq_install/binary.py
+++ b/scripts/install/src/cq_install/binary.py
@@ -26,22 +26,22 @@ def ensure_cq_binary(plugin_root: Path, *, dry_run: bool = False) -> list[Change
     """Guarantee the cq binary is cached at the shared runtime path.
 
     Loads ``plugin_root/scripts/cq_binary.py`` via importlib and calls
-    its ``ensure_binary`` with the required version from
+    its ``ensure_binary`` with the minimum version from
     ``bootstrap.json``. Returns a single-element list of ``ChangeResult``
     so callers can extend their own result lists uniformly.
     """
     module = _load_cq_binary(plugin_root)
 
     metadata_path = plugin_root / BOOTSTRAP_METADATA_RELPATH
-    required_version = module.load_required_version(metadata_path)
-    if not required_version:
-        raise RuntimeError(f"cq bootstrap metadata missing cli_version at {metadata_path}")
+    min_version = module.load_min_version(metadata_path)
+    if not min_version:
+        raise RuntimeError(f"cq bootstrap metadata missing cli_min_version at {metadata_path}")
 
     bin_dir = module.shared_bin_dir()
     binary = bin_dir / module.cq_binary_name()
 
-    already_valid = binary.is_file() and module.check_version(binary, required_version)
-    detail_cached = f"cq v{required_version}"
+    already_valid = binary.is_file() and module.meets_min_version(binary, min_version)
+    detail_cached = f"cq v{min_version}"
 
     if dry_run:
         if already_valid:
@@ -50,14 +50,14 @@ def ensure_cq_binary(plugin_root: Path, *, dry_run: bool = False) -> list[Change
             ChangeResult(
                 action=Action.SKIPPED,
                 path=binary,
-                detail=f"would fetch cq v{required_version}",
+                detail=f"would fetch cq v{min_version}",
             )
         ]
 
     if already_valid:
         return [ChangeResult(action=Action.UNCHANGED, path=binary, detail=detail_cached)]
 
-    module.ensure_binary(binary, required_version, bin_dir)
+    module.ensure_binary(binary, min_version, bin_dir)
     return [ChangeResult(action=Action.CREATED, path=binary, detail=detail_cached)]
 
 

--- a/scripts/install/tests/conftest.py
+++ b/scripts/install/tests/conftest.py
@@ -44,7 +44,7 @@ def plugin_root(tmp_path: Path) -> Path:
     (root / ".claude-plugin").mkdir(parents=True)
     (root / ".claude-plugin" / "plugin.json").write_text('{"name": "cq", "version": "0.7.0"}\n')
     (root / "scripts").mkdir(parents=True)
-    (root / "scripts" / "bootstrap.json").write_text('{"cli_version": "0.2.0"}\n')
+    (root / "scripts" / "bootstrap.json").write_text('{"cli_min_version": "0.2.0"}\n')
     (root / "scripts" / "bootstrap.py").write_text("# fake bootstrap\n")
     (root / "scripts" / "cq_binary.py").write_text("# fake cq_binary\n")
     (root / "skills" / "cq").mkdir(parents=True)

--- a/scripts/install/tests/test_binary.py
+++ b/scripts/install/tests/test_binary.py
@@ -20,11 +20,11 @@ FAKE_CQ_BINARY = dedent(
     _MARKER_DIR = Path(__file__).resolve().parent.parent
 
 
-    def load_required_version(metadata_path):
+    def load_min_version(metadata_path):
         if not metadata_path.exists():
             return ""
         with open(metadata_path) as f:
-            return json.load(f).get("cli_version", "")
+            return json.load(f).get("cli_min_version", "")
 
 
     def shared_bin_dir():
@@ -35,27 +35,27 @@ FAKE_CQ_BINARY = dedent(
         return "cq"
 
 
-    def check_version(binary, required):
+    def meets_min_version(binary, min_version):
         if not binary.is_file():
             return False
-        return binary.read_text().strip() == required
+        return binary.read_text().strip() == min_version
 
 
-    def ensure_binary(binary, required_version, bin_dir):
+    def ensure_binary(binary, min_version, bin_dir):
         bin_dir.mkdir(parents=True, exist_ok=True)
-        binary.write_text(required_version)
+        binary.write_text(min_version)
         (_MARKER_DIR / ".ensure_called").write_text(
-            f"{binary}|{required_version}|{bin_dir}"
+            f"{binary}|{min_version}|{bin_dir}"
         )
     '''
 )
 
 
-def _seed_plugin_tree(plugin_root: Path, *, cli_version: str | None = "0.2.0") -> None:
+def _seed_plugin_tree(plugin_root: Path, *, cli_min_version: str | None = "0.2.0") -> None:
     scripts = plugin_root / "scripts"
     scripts.mkdir(parents=True, exist_ok=True)
-    if cli_version is not None:
-        (scripts / "bootstrap.json").write_text(f'{{"cli_version": "{cli_version}"}}\n')
+    if cli_min_version is not None:
+        (scripts / "bootstrap.json").write_text(f'{{"cli_min_version": "{cli_min_version}"}}\n')
     (scripts / "cq_binary.py").write_text(FAKE_CQ_BINARY)
 
 
@@ -116,7 +116,7 @@ def test_ensure_cq_binary_dry_run_is_unchanged_when_already_valid(tmp_path):
 def test_ensure_cq_binary_raises_when_cq_binary_missing(tmp_path):
     plugin_root = tmp_path / "plugins" / "cq"
     (plugin_root / "scripts").mkdir(parents=True)
-    (plugin_root / "scripts" / "bootstrap.json").write_text('{"cli_version": "0.2.0"}\n')
+    (plugin_root / "scripts" / "bootstrap.json").write_text('{"cli_min_version": "0.2.0"}\n')
 
     with pytest.raises(RuntimeError, match="cq_binary.py"):
         ensure_cq_binary(plugin_root)
@@ -124,7 +124,7 @@ def test_ensure_cq_binary_raises_when_cq_binary_missing(tmp_path):
 
 def test_ensure_cq_binary_raises_when_version_missing(tmp_path):
     plugin_root = tmp_path / "plugins" / "cq"
-    _seed_plugin_tree(plugin_root, cli_version=None)
+    _seed_plugin_tree(plugin_root, cli_min_version=None)
 
-    with pytest.raises(RuntimeError, match="cli_version"):
+    with pytest.raises(RuntimeError, match="cli_min_version"):
         ensure_cq_binary(plugin_root)

--- a/scripts/install/tests/test_binary.py
+++ b/scripts/install/tests/test_binary.py
@@ -41,6 +41,12 @@ FAKE_CQ_BINARY = dedent(
         return binary.read_text().strip() == min_version
 
 
+    def parse_version(binary):
+        if not binary.is_file():
+            return ""
+        return binary.read_text().strip()
+
+
     def ensure_binary(binary, min_version, bin_dir):
         bin_dir.mkdir(parents=True, exist_ok=True)
         binary.write_text(min_version)

--- a/scripts/install/tests/test_cli.py
+++ b/scripts/install/tests/test_cli.py
@@ -30,7 +30,7 @@ def fake_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     (plugin_root / ".claude-plugin").mkdir(parents=True)
     (plugin_root / ".claude-plugin" / "plugin.json").write_text('{"name": "cq", "version": "0.7.0"}\n')
     (plugin_root / "scripts").mkdir(parents=True)
-    (plugin_root / "scripts" / "bootstrap.json").write_text('{"cli_version": "0.2.0"}\n')
+    (plugin_root / "scripts" / "bootstrap.json").write_text('{"cli_min_version": "0.2.0"}\n')
     (plugin_root / "scripts" / "bootstrap.py").write_text("# fake\n")
     (plugin_root / "scripts" / "cq_binary.py").write_text("# fake cq_binary\n")
     (plugin_root / "skills" / "cq").mkdir(parents=True)

--- a/scripts/install/tests/test_context.py
+++ b/scripts/install/tests/test_context.py
@@ -59,7 +59,7 @@ def test_ensure_cq_binary_runs_once_per_run_state(tmp_path: Path, monkeypatch: p
     plugin_root = tmp_path / "plugins" / "cq"
     (plugin_root / "scripts").mkdir(parents=True)
     (plugin_root / "scripts" / "cq_binary.py").touch()
-    (plugin_root / "scripts" / "bootstrap.json").write_text('{"cli_version": "0.2.0"}\n')
+    (plugin_root / "scripts" / "bootstrap.json").write_text('{"cli_min_version": "0.2.0"}\n')
 
     calls: list[Path] = []
     sample_result = ChangeResult(action=Action.CREATED, path=tmp_path / "cq", detail="cq v0.2.0")


### PR DESCRIPTION
## Summary

- Replaces the exact `cli_version` match in the plugin bootstrap with a `cli_min_version` field and `>=` semver comparison using tuple-based integer comparison.
- The plugin no longer needs a release for every CLI version bump; only when it genuinely requires a newer CLI feature.
- Renames `check_version` -> `meets_min_version`, `load_required_version` -> `load_min_version` to reflect the new semantics.

## Test plan

- [x] Existing tests updated and passing (`make test`)
- [x] New tests for `>=` behaviour: exact match, newer major/minor/patch, older, empty version
- [x] New tests for `parse_semver` helper
- [x] Test that old `cli_version` key is ignored by `load_min_version`
- [x] Linters pass (`make lint`)