### PR TITLE
Bump plugin version to 0.7.1

### DIFF
--- a/plugins/cq/.claude-plugin/plugin.json
+++ b/plugins/cq/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cq",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Shared knowledge commons for AI agents; find, share, and confirm collective knowledge to stop rediscovering the same failures.",
   "author": {
     "name": "Mozilla AI",

--- a/plugins/cq/pyproject.toml
+++ b/plugins/cq/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cq-plugin"
-version = "0.7.0"
+version = "0.7.1"
 description = "cq Plugin for coding agents (e.g. Claude Code, OpenCode) - shared agent knowledge commons"
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }

--- a/plugins/cq/uv.lock
+++ b/plugins/cq/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "cq-plugin"
-version = "0.7.0"
+version = "0.7.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Bumps plugin version from 0.7.0 to 0.7.1 in plugin.json, pyproject.toml, and uv.lock.
- Follows the cli_min_version bootstrap change merged in #265.

## Test plan

- [x] `uv lock --check` passes (verified by pre-commit hook)