### PR TITLE
fix: add local pre-commit configs to prevent double lint runs

### DIFF
--- a/plugins/cq/.pre-commit-config.yaml
+++ b/plugins/cq/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-merge-conflict
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.4
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+  - repo: local
+    hooks:
+      - id: ty-check-install
+        name: ty (scripts/install)
+        entry: bash -c 'cd ../scripts/install && uvx ty check src/cq_install --python .venv'
+        language: system
+        pass_filenames: false

--- a/server/backend/.pre-commit-config.yaml
+++ b/server/backend/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-merge-conflict
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.4
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+  - repo: local
+    hooks:
+      - id: ty-check-install
+        name: ty (scripts/install)
+        entry: bash -c 'cd ../../scripts/install && uvx ty check src/cq_install --python .venv'
+        language: system
+        pass_filenames: false


### PR DESCRIPTION
Fixes issue #251: Refactor make lint: root pre-commit config runs twice

By adding local .pre-commit-config.yaml files to plugins/cq/ and server/backend/,
these directories will no longer walk up to the root config during `make lint`,
preventing the root hooks from running twice.

The configs mirror the root config's hooks but are scoped to each directory.

This resolves the issue where `make lint` was executing root pre-commit hooks
twice - once via the individual component lint targets and once via the
check-skill-sync or other shared initialization steps.