### PR TITLE
Add VIBE√ safety check to /cq:reflect (#240)

### DIFF
--- a/plugins/cq/commands/reflect.md
+++ b/plugins/cq/commands/reflect.md
@@ -61,17 +61,58 @@ For each candidate, assign:
   - 0.2–0.5: applicable only under narrow conditions.
 - Optionally: **languages**, **frameworks**, **pattern** if relevant.
 
+#### VIBE√ safety criteria
+
+Each candidate must also be evaluated against four safety dimensions before it can be presented:
+
+- **V — Vulnerabilities**: Does the candidate contain or reveal credentials, API keys, tokens, internal hostnames, IP addresses, file paths that disclose user identity, or any other secret that should not leave this machine? Does the action it recommends introduce a security risk if applied blindly (e.g. disabling auth checks, weakening TLS, executing untrusted input)?
+- **I — Impact**: If another agent applied this candidate verbatim in an unrelated codebase, what is the worst plausible outcome? Could it cause data loss, production incidents, or cascading failures?
+- **B — Biases**: Is the framing tied to a specific person, team, vendor, or commercial product in a way that isn't load-bearing for the lesson? Does it present one tool/approach as universally correct when the evidence supports only a narrow context?
+- **E — Edge cases**: Was the lesson learned from a single observation, or has it been validated across multiple cases? Are there obvious conditions (OS, version, scale, concurrency) under which it would not hold and that the candidate fails to acknowledge?
+
 If the session contained no events meeting the above criteria, skip Steps 3–5 and follow the "no candidates" instruction in Step 6.
+
+### Step 2.5 — Run the VIBE√ check on each candidate
+
+Before presenting candidates to the user, evaluate every candidate from Step 2 against the four VIBE√ criteria. Classify each finding into one of two tiers. Candidates are never dropped automatically — `/cq:reflect` writes to the user's local cq tier, and the user owns the decision about what is acceptable to store there.
+
+**Hard findings** — the candidate is presented in Step 3 with both the original and a sanitized rewrite, so the user can choose which (if either) to store:
+
+- Literal credentials, API keys, access tokens, private keys, or session cookies.
+- Personally identifying information: real names, email addresses, phone numbers, government IDs, physical addresses.
+- Internal-only identifiers that uniquely fingerprint a private system: non-public hostnames, internal service names, customer IDs, ticket numbers from private trackers.
+- Recommendations whose primary effect is to weaken security (disable auth, skip signature verification, suppress sandboxing) without a clearly scoped, defensive justification.
+
+For each hard finding, generate a single sanitized rewrite that removes or generalizes the violating content while preserving the underlying lesson. If no coherent lesson survives sanitization, present the original alongside an empty-rewrite note ("no sanitized version possible — original would not generalize once stripped"); the user can still choose to keep the original locally or skip.
+
+**Soft concerns** — the candidate is presented as-is, with a one-line concern flag the user can weigh during approval:
+
+- Framing that overgeneralizes from a single observation.
+- Vendor- or product-specific advice presented as universal.
+- Missing acknowledgement of an edge case the session itself surfaced.
+- Wording that could read as biased toward a specific team, person, or commercial product.
+- Impact that the agent cannot fully predict (e.g. action mutates shared state).
+
+Track outcomes for the Step 3 and Step 6 reports:
+
+- Candidates that passed cleanly.
+- Candidates with hard findings (record the concern; have the sanitized rewrite ready for presentation).
+- Candidates with soft concerns (record the concern per candidate).
 
 ### Step 3 — Present candidates to the user
 
 Open with:
 
 ```
-I identified {N} potential learning candidates from this session worth sharing with the commons.
+I identified {N_total} potential learning candidates from this session.
+{N_hard} have hard concerns and are shown with both the original and a sanitized rewrite — pick which (if either) to store.
+{N_soft} have soft concerns flagged with ⚠️ for your awareness.
+{N_clean} passed the VIBE√ check cleanly.
 ```
 
-Present each candidate as a numbered entry:
+Present each candidate as a numbered entry. Use one of three templates depending on what Step 2.5 produced.
+
+**Clean candidate:**
 
 ```
 {N}. {summary}
@@ -82,11 +123,42 @@ Present each candidate as a numbered entry:
    Action: {action}
 ```
 
+**Soft-concern candidate** (add the `⚠️` line above the divider):
+
+```
+{N}. {summary}
+   Domains: {domain tags}
+   Relevance: {estimated_relevance}
+   ⚠️ {one-line concern}
+   ---
+   {detail}
+   Action: {action}
+```
+
+**Hard-finding candidate** (show both versions side by side, with the concern annotated):
+
+```
+{N}. {summary}
+   Domains: {domain tags}
+   Relevance: {estimated_relevance}
+   ⚠️ Hard concern: {one-line concern}
+   ---
+   Original:
+     {original detail}
+     Action: {original action}
+   Sanitized:
+     {rewritten detail}
+     Action: {rewritten action}
+```
+
+If the sanitized rewrite is not coherent (per the Step 2.5 fallback), substitute the Sanitized block with: `Sanitized: (no sanitized version possible — original would not generalize once stripped)`.
+
 After listing all candidates, ask:
 
 ```
 Reply with a number to approve, "skip {N}" to discard, or "edit {N}" to revise.
-You can also reply "all" to approve everything, or "none" to discard everything.
+For candidates with both an Original and a Sanitized version shown, use "{N} original" or "{N} sanitized" to choose which to store.
+You can also reply "all" to approve everything (sanitized version where applicable), or "none" to discard everything.
 ```
 
 ### Step 4 — Handle edits
@@ -123,12 +195,23 @@ Stored: {id} — "{summary}"
 ## Session Reflect Complete
 
 {approved} of {total} candidates proposed to cq.
-{skipped} skipped.
+{skipped} skipped by user.
+
+VIBE√ findings this session:
+- Hard concerns (candidates {numbers}): {one-line concern per candidate}
+- Soft concerns (candidates {numbers}): {one-line concern per candidate}
 
 IDs stored this session:
-- {id}: "{summary}"
+- {id}: "{summary}" [{clean | soft | sanitized | original}]
 - ...
 ```
+
+The bracketed annotation on each stored ID records the VIBE√ provenance of what was stored:
+
+- `clean` — no VIBE√ findings; stored as identified.
+- `soft` — soft concern present; stored as-is after the user weighed the flag.
+- `sanitized` — hard finding; the user picked the sanitized rewrite.
+- `original` — hard finding; the user explicitly picked the unmodified version.
 
 If no candidates were identified, display:
 
@@ -141,3 +224,5 @@ No shareable learnings identified in this session. Sessions with debugging, work
 - **Empty session** — If the session contained only routine tasks, say so and stop after Step 2.
 - **All candidates skipped** — Display the summary with 0 proposed.
 - **`propose` error** — Report the error inline for that candidate and continue with the next one. Do not abort.
+- **`reflect` returns candidates** — Present them alongside any additional candidates you identified. Deduplicate by summary similarity before presenting.
+- **No coherent sanitized rewrite possible** — Present the original with the empty-rewrite note from Step 2.5. The user can still choose to keep the original locally or skip; do not silently drop the candidate.

--- a/plugins/cq/commands/reflect.md
+++ b/plugins/cq/commands/reflect.md
@@ -74,7 +74,7 @@ If the session contained no events meeting the above criteria, skip Steps 3–5 
 
 ### Step 2.5 — Run the VIBE√ check on each candidate
 
-Before presenting candidates to the user, evaluate every candidate from Step 2 against the four VIBE√ criteria. Classify each finding into one of two tiers. Candidates are never dropped automatically — `/cq:reflect` writes to the user's local cq tier, and the user owns the decision about what is acceptable to store there.
+Before presenting candidates to the user, evaluate every candidate from Step 2 against the four VIBE√ criteria. Classify each finding into one of two tiers. Candidates are never dropped automatically — `/cq:reflect` proposes each approved candidate via `propose`, which routes to the configured remote cq server when `CQ_ADDR` is set (falling back to local on auth reject or unreachable) and to the local store otherwise. The user owns the decision about what is acceptable to submit.
 
 **Hard findings** — the candidate is presented in Step 3 with both the original and a sanitized rewrite, so the user can choose which (if either) to store:
 

--- a/plugins/cq/commands/reflect.md
+++ b/plugins/cq/commands/reflect.md
@@ -61,43 +61,13 @@ For each candidate, assign:
   - 0.2–0.5: applicable only under narrow conditions.
 - Optionally: **languages**, **frameworks**, **pattern** if relevant.
 
-#### VIBE√ safety criteria
-
-Each candidate must also be evaluated against four safety dimensions before it can be presented:
-
-- **V — Vulnerabilities**: Does the candidate contain or reveal credentials, API keys, tokens, internal hostnames, IP addresses, file paths that disclose user identity, or any other secret that should not leave this machine? Does the action it recommends introduce a security risk if applied blindly (e.g. disabling auth checks, weakening TLS, executing untrusted input)?
-- **I — Impact**: If another agent applied this candidate verbatim in an unrelated codebase, what is the worst plausible outcome? Could it cause data loss, production incidents, or cascading failures?
-- **B — Biases**: Is the framing tied to a specific person, team, vendor, or commercial product in a way that isn't load-bearing for the lesson? Does it present one tool/approach as universally correct when the evidence supports only a narrow context?
-- **E — Edge cases**: Was the lesson learned from a single observation, or has it been validated across multiple cases? Are there obvious conditions (OS, version, scale, concurrency) under which it would not hold and that the candidate fails to acknowledge?
-
 If the session contained no events meeting the above criteria, skip Steps 3–5 and follow the "no candidates" instruction in Step 6.
 
-### Step 2.5 — Run the VIBE√ check on each candidate
+### Step 2.5 — Run the VIBE√ safety check on each candidate
 
-Before presenting candidates to the user, evaluate every candidate from Step 2 against the four VIBE√ criteria. Classify each finding into one of two tiers. Candidates are never dropped automatically — `/cq:reflect` proposes each approved candidate via `propose`, which routes to the configured remote cq server when `CQ_ADDR` is set (falling back to local on auth reject or unreachable) and to the local store otherwise. The user owns the decision about what is acceptable to submit.
+Apply the VIBE√ safety check as defined in the cq skill against every candidate from Step 2. Classify each finding as clean, soft-concern, or hard-finding; for hard findings, generate the sanitized rewrite. Record the classification per candidate — Steps 3 and 6 use these results for presentation and the final summary.
 
-**Hard findings** — the candidate is presented in Step 3 with both the original and a sanitized rewrite, so the user can choose which (if either) to store:
-
-- Literal credentials, API keys, access tokens, private keys, or session cookies.
-- Personally identifying information: real names, email addresses, phone numbers, government IDs, physical addresses.
-- Internal-only identifiers that uniquely fingerprint a private system: non-public hostnames, internal service names, customer IDs, ticket numbers from private trackers.
-- Recommendations whose primary effect is to weaken security (disable auth, skip signature verification, suppress sandboxing) without a clearly scoped, defensive justification.
-
-For each hard finding, generate a single sanitized rewrite that removes or generalizes the violating content while preserving the underlying lesson. If no coherent lesson survives sanitization, present the original alongside an empty-rewrite note ("no sanitized version possible — original would not generalize once stripped"); the user can still choose to keep the original locally or skip.
-
-**Soft concerns** — the candidate is presented as-is, with a one-line concern flag the user can weigh during approval:
-
-- Framing that overgeneralizes from a single observation.
-- Vendor- or product-specific advice presented as universal.
-- Missing acknowledgement of an edge case the session itself surfaced.
-- Wording that could read as biased toward a specific team, person, or commercial product.
-- Impact that the agent cannot fully predict (e.g. action mutates shared state).
-
-Track outcomes for the Step 3 and Step 6 reports:
-
-- Candidates that passed cleanly.
-- Candidates with hard findings (record the concern; have the sanitized rewrite ready for presentation).
-- Candidates with soft concerns (record the concern per candidate).
+`/cq:reflect` never drops candidates automatically; the user owns the final decision about what to submit.
 
 ### Step 3 — Present candidates to the user
 

--- a/plugins/cq/commands/reflect.md
+++ b/plugins/cq/commands/reflect.md
@@ -176,7 +176,8 @@ Stored: {id} — "{summary}"
 ```
 ## Session Reflect Complete
 
-{total} candidates identified. {excluded} dropped by VIBE√ (not generalizable; not presented).
+{total} candidates identified.
+{excluded} dropped by VIBE√ (not generalizable; not presented).
 {approved} proposed to cq. {skipped} skipped by user.
 
 VIBE√ findings this session:
@@ -189,7 +190,7 @@ IDs stored this session:
 - ...
 ```
 
-Omit any VIBE√ findings line whose category has no entries, and omit the `excluded` count sentence if zero.
+Always show the `{total} candidates identified.` line. Omit the `{excluded} dropped by VIBE√ ...` sentence when `{excluded}` is zero. Omit any VIBE√ findings bullet whose category has no entries.
 
 The bracketed annotation on each stored ID records the VIBE√ provenance of what was stored:
 

--- a/plugins/cq/commands/reflect.md
+++ b/plugins/cq/commands/reflect.md
@@ -65,27 +65,31 @@ If the session contained no events meeting the above criteria, skip Steps 3–5 
 
 ### Step 2.5 — Run the VIBE√ safety check on each candidate
 
-Apply the VIBE√ safety check as defined in the cq skill against every candidate from Step 2. Classify each finding as clean, soft-concern, or hard-finding; for hard findings, generate the sanitized rewrite. Record the classification per candidate — Steps 3 and 6 use these results for presentation and the final summary.
+Apply the VIBE√ safety check as defined in the cq skill against every candidate from Step 2. Classify each finding as clean, soft-concern, or hard-finding. For hard findings, generate the sanitized rewrite covering every `propose` field that could carry the violating content (`summary`, `detail`, `action`, `domains`, `languages`, `frameworks`, `pattern`). Record the classification per candidate — Steps 3 and 6 use these results for presentation and the final summary.
 
-`/cq:reflect` never drops candidates automatically; the user owns the final decision about what to submit.
+If a hard finding cannot be coherently sanitized, the candidate fails Step 2's generalizable criterion — drop it from the candidate list and record the exclusion in Step 6's summary. Do not present it. `/cq:reflect` never silently drops *presented* candidates; the user owns the final decision on every candidate that reaches Step 3.
 
 ### Step 3 — Present candidates to the user
 
 Open with:
 
 ```
-I identified {N_total} potential learning candidates from this session.
-{N_hard} have hard concerns and are shown with both the original and a sanitized rewrite — pick which (if either) to store.
-{N_soft} have soft concerns flagged with ⚠️ for your awareness.
-{N_clean} passed the VIBE√ check cleanly.
+cq identified {total} potential learning candidates from this session...
+
+{hard} have hard concerns and are shown with both the original and a sanitized rewrite — pick which (if either) to store.
+{soft} have soft concerns flagged with ⚠️ for your awareness.
+{clean} passed the VIBE√ check cleanly.
 ```
 
-Present each candidate as a numbered entry. Use one of three templates depending on what Step 2.5 produced.
+Omit any count line whose value is zero.
+
+Present each candidate as a numbered entry. Use one of three templates depending on what Step 2.5 produced. Every template has a blank line after the `{N}. {summary}` header so the metadata block is visually distinct.
 
 **Clean candidate:**
 
 ```
 {N}. {summary}
+
    Domains: {domain tags}
    Relevance: {estimated_relevance}
    ---
@@ -93,42 +97,50 @@ Present each candidate as a numbered entry. Use one of three templates depending
    Action: {action}
 ```
 
-**Soft-concern candidate** (add the `⚠️` line above the divider):
+**Soft-concern candidate** (add the `⚠️` line as the first line of the metadata block, above `Domains`):
 
 ```
 {N}. {summary}
-   Domains: {domain tags}
-   Relevance: {estimated_relevance}
+
    ⚠️ {one-line concern}
+   Domains: {domain tags}
+   Relevance: {estimated_relevance}
    ---
    {detail}
    Action: {action}
 ```
 
-**Hard-finding candidate** (show both versions side by side, with the concern annotated):
+**Hard-finding candidate.** The header `summary` and `Domains` use the sanitized values — the header never shows hard-finding content. The Original block shows the full original fields (summary, domains, detail, action). The Sanitized block shows only fields that differ from the header, i.e. detail and action.
 
 ```
-{N}. {summary}
-   Domains: {domain tags}
-   Relevance: {estimated_relevance}
+{N}. {sanitized summary}
+
    ⚠️ Hard concern: {one-line concern}
+   Domains: {sanitized domain tags}
+   Relevance: {estimated_relevance}
    ---
    Original:
-     {original detail}
+     Summary: {original summary}
+     Domains: {original domain tags}
+     Detail: {original detail}
      Action: {original action}
    Sanitized:
-     {rewritten detail}
-     Action: {rewritten action}
+     Detail: {sanitized detail}
+     Action: {sanitized action}
 ```
 
-If the sanitized rewrite is not coherent (per the Step 2.5 fallback), substitute the Sanitized block with: `Sanitized: (no sanitized version possible — original would not generalize once stripped)`.
-
-After listing all candidates, ask:
+After listing all candidates, show the command reference:
 
 ```
-Reply with a number to approve, "skip {N}" to discard, or "edit {N}" to revise.
-For candidates with both an Original and a Sanitized version shown, use "{N} original" or "{N} sanitized" to choose which to store.
-You can also reply "all" to approve everything (sanitized version where applicable), or "none" to discard everything.
+Commands:
+  N              approve (sanitized version for hard-findings)
+  N original     approve original instead (hard-findings only)
+  edit N         revise before storing
+  skip N         discard
+  all            approve every candidate's default
+  none           discard everything
+
+Combine with commas: e.g. "1, 3 original, skip 2" applies each command in order.
 ```
 
 ### Step 4 — Handle edits
@@ -164,17 +176,20 @@ Stored: {id} — "{summary}"
 ```
 ## Session Reflect Complete
 
-{approved} of {total} candidates proposed to cq.
-{skipped} skipped by user.
+{total} candidates identified. {excluded} dropped by VIBE√ (not generalizable; not presented).
+{approved} proposed to cq. {skipped} skipped by user.
 
 VIBE√ findings this session:
 - Hard concerns (candidates {numbers}): {one-line concern per candidate}
 - Soft concerns (candidates {numbers}): {one-line concern per candidate}
+- Excluded (not presented): {one-line reason per excluded candidate}
 
 IDs stored this session:
 - {id}: "{summary}" [{clean | soft | sanitized | original}]
 - ...
 ```
+
+Omit any VIBE√ findings line whose category has no entries, and omit the `excluded` count sentence if zero.
 
 The bracketed annotation on each stored ID records the VIBE√ provenance of what was stored:
 
@@ -194,4 +209,3 @@ No shareable learnings identified in this session. Sessions with debugging, work
 - **Empty session** — If the session contained only routine tasks, say so and stop after Step 2.
 - **All candidates skipped** — Display the summary with 0 proposed.
 - **`propose` error** — Report the error inline for that candidate and continue with the next one. Do not abort.
-- **No coherent sanitized rewrite possible** — Present the original with the empty-rewrite note from Step 2.5. The user can still choose to keep the original locally or skip; do not silently drop the candidate.

--- a/plugins/cq/commands/reflect.md
+++ b/plugins/cq/commands/reflect.md
@@ -224,5 +224,4 @@ No shareable learnings identified in this session. Sessions with debugging, work
 - **Empty session** — If the session contained only routine tasks, say so and stop after Step 2.
 - **All candidates skipped** — Display the summary with 0 proposed.
 - **`propose` error** — Report the error inline for that candidate and continue with the next one. Do not abort.
-- **`reflect` returns candidates** — Present them alongside any additional candidates you identified. Deduplicate by summary similarity before presenting.
 - **No coherent sanitized rewrite possible** — Present the original with the empty-rewrite note from Step 2.5. The user can still choose to keep the original locally or skip; do not silently drop the candidate.

--- a/plugins/cq/skills/cq/SKILL.md
+++ b/plugins/cq/skills/cq/SKILL.md
@@ -154,7 +154,9 @@ Classify each finding into one of two tiers. Candidates are never dropped automa
 - Internal-only identifiers that uniquely fingerprint a private system: non-public hostnames, internal service names, customer IDs, ticket numbers from private trackers.
 - Recommendations whose primary effect is to weaken security (disable auth, skip signature verification, suppress sandboxing) without a clearly scoped, defensive justification.
 
-Generate a single sanitized rewrite that removes or generalizes the violating content while preserving the underlying lesson. If no coherent lesson survives sanitization, flag the candidate as having no coherent rewrite — the user can still choose to keep the original or skip.
+Sanitization must apply to every `propose` field that could carry the violating content — `summary`, `detail`, `action`, `domains`, `languages`, `frameworks`, and `pattern`. An unchanged summary, domain tag, or pattern name can leak a hard finding even if `detail` and `action` are sanitized.
+
+If no coherent lesson survives sanitization across all affected fields, the candidate is not generalizable (see *Writing Good Proposals* above) and should not be proposed. Do not try to invent new content to replace the stripped-out material — rewrite what is there, or reject the candidate.
 
 **Soft concerns** — proceed with the candidate, flag the concern to the user before calling `propose`:
 

--- a/plugins/cq/skills/cq/SKILL.md
+++ b/plugins/cq/skills/cq/SKILL.md
@@ -136,6 +136,39 @@ Provide all three insight fields:
 - **detail** — Fuller explanation with enough context to understand the issue. Include a timestamp and source where possible.
 - **action** — Concrete instruction on what to do about it. Prefer principle + verification method over exact values.
 
+#### VIBE√ safety check
+
+Before calling `propose`, evaluate every candidate against four safety dimensions. This applies to all propose calls — those triggered by `/cq:reflect` and direct proposes made while working on a task.
+
+- **V — Vulnerabilities**: Does the candidate contain or reveal credentials, API keys, tokens, internal hostnames, IP addresses, file paths that disclose user identity, or any other secret? Does the action it recommends introduce a security risk if applied blindly (e.g. disabling auth checks, weakening TLS, executing untrusted input)?
+- **I — Impact**: If another agent applied this candidate verbatim in an unrelated codebase, what is the worst plausible outcome? Could it cause data loss, production incidents, or cascading failures?
+- **B — Biases**: Is the framing tied to a specific person, team, vendor, or commercial product in a way that isn't load-bearing for the lesson? Does it present one tool/approach as universally correct when the evidence supports only a narrow context?
+- **E — Edge cases**: Was the lesson learned from a single observation, or has it been validated across multiple cases? Are there obvious conditions (OS, version, scale, concurrency) under which it would not hold and that the candidate fails to acknowledge?
+
+Classify each finding into one of two tiers. Candidates are never dropped automatically — the user owns the final decision.
+
+**Hard findings** — produce a sanitized rewrite before calling `propose`:
+
+- Literal credentials, API keys, access tokens, private keys, or session cookies.
+- Personally identifying information: real names, email addresses, phone numbers, government IDs, physical addresses.
+- Internal-only identifiers that uniquely fingerprint a private system: non-public hostnames, internal service names, customer IDs, ticket numbers from private trackers.
+- Recommendations whose primary effect is to weaken security (disable auth, skip signature verification, suppress sandboxing) without a clearly scoped, defensive justification.
+
+Generate a single sanitized rewrite that removes or generalizes the violating content while preserving the underlying lesson. If no coherent lesson survives sanitization, flag the candidate as having no coherent rewrite — the user can still choose to keep the original or skip.
+
+**Soft concerns** — proceed with the candidate, flag the concern to the user before calling `propose`:
+
+- Framing that overgeneralizes from a single observation.
+- Vendor- or product-specific advice presented as universal.
+- Missing acknowledgement of an edge case the session itself surfaced.
+- Wording that could read as biased toward a specific team, person, or commercial product.
+- Impact that the agent cannot fully predict (e.g. action mutates shared state).
+
+#### Applying VIBE√
+
+- **Direct `propose` calls** (outside `/cq:reflect`) — run the check on the single candidate. If a hard finding exists, present both the original and the sanitized rewrite to the user and let them pick (or skip). If only a soft concern exists, present the concern for awareness before proceeding.
+- **Batch proposals via `/cq:reflect`** — see the `/cq:reflect` command for the batch presentation UX (three templates, provenance annotation). The underlying V/I/B/E classification rules are the same.
+
 ### Confirming Knowledge (`confirm`)
 
 Call `confirm` when a knowledge unit retrieved from a query proved correct during your session. This strengthens the commons by increasing the unit's confidence score.

--- a/plugins/cq/skills/cq/SKILL.md
+++ b/plugins/cq/skills/cq/SKILL.md
@@ -145,7 +145,7 @@ Before calling `propose`, evaluate every candidate against four safety dimension
 - **B — Biases**: Is the framing tied to a specific person, team, vendor, or commercial product in a way that isn't load-bearing for the lesson? Does it present one tool/approach as universally correct when the evidence supports only a narrow context?
 - **E — Edge cases**: Was the lesson learned from a single observation, or has it been validated across multiple cases? Are there obvious conditions (OS, version, scale, concurrency) under which it would not hold and that the candidate fails to acknowledge?
 
-Classify each finding into one of two tiers. Candidates are never dropped automatically — the user owns the final decision.
+Classify each finding into one of two tiers. The user owns the final decision on every candidate that reaches review — candidates are never silently dropped at that stage. Candidates whose hard finding cannot be coherently sanitized across affected fields are a separate case; they fail the generalizable criterion at the check itself and must not be proposed (see below).
 
 **Hard findings** — produce a sanitized rewrite before calling `propose`:
 

--- a/sdk/go/prompts/SKILL.md
+++ b/sdk/go/prompts/SKILL.md
@@ -154,7 +154,9 @@ Classify each finding into one of two tiers. Candidates are never dropped automa
 - Internal-only identifiers that uniquely fingerprint a private system: non-public hostnames, internal service names, customer IDs, ticket numbers from private trackers.
 - Recommendations whose primary effect is to weaken security (disable auth, skip signature verification, suppress sandboxing) without a clearly scoped, defensive justification.
 
-Generate a single sanitized rewrite that removes or generalizes the violating content while preserving the underlying lesson. If no coherent lesson survives sanitization, flag the candidate as having no coherent rewrite — the user can still choose to keep the original or skip.
+Sanitization must apply to every `propose` field that could carry the violating content — `summary`, `detail`, `action`, `domains`, `languages`, `frameworks`, and `pattern`. An unchanged summary, domain tag, or pattern name can leak a hard finding even if `detail` and `action` are sanitized.
+
+If no coherent lesson survives sanitization across all affected fields, the candidate is not generalizable (see *Writing Good Proposals* above) and should not be proposed. Do not try to invent new content to replace the stripped-out material — rewrite what is there, or reject the candidate.
 
 **Soft concerns** — proceed with the candidate, flag the concern to the user before calling `propose`:
 

--- a/sdk/go/prompts/SKILL.md
+++ b/sdk/go/prompts/SKILL.md
@@ -136,6 +136,39 @@ Provide all three insight fields:
 - **detail** — Fuller explanation with enough context to understand the issue. Include a timestamp and source where possible.
 - **action** — Concrete instruction on what to do about it. Prefer principle + verification method over exact values.
 
+#### VIBE√ safety check
+
+Before calling `propose`, evaluate every candidate against four safety dimensions. This applies to all propose calls — those triggered by `/cq:reflect` and direct proposes made while working on a task.
+
+- **V — Vulnerabilities**: Does the candidate contain or reveal credentials, API keys, tokens, internal hostnames, IP addresses, file paths that disclose user identity, or any other secret? Does the action it recommends introduce a security risk if applied blindly (e.g. disabling auth checks, weakening TLS, executing untrusted input)?
+- **I — Impact**: If another agent applied this candidate verbatim in an unrelated codebase, what is the worst plausible outcome? Could it cause data loss, production incidents, or cascading failures?
+- **B — Biases**: Is the framing tied to a specific person, team, vendor, or commercial product in a way that isn't load-bearing for the lesson? Does it present one tool/approach as universally correct when the evidence supports only a narrow context?
+- **E — Edge cases**: Was the lesson learned from a single observation, or has it been validated across multiple cases? Are there obvious conditions (OS, version, scale, concurrency) under which it would not hold and that the candidate fails to acknowledge?
+
+Classify each finding into one of two tiers. Candidates are never dropped automatically — the user owns the final decision.
+
+**Hard findings** — produce a sanitized rewrite before calling `propose`:
+
+- Literal credentials, API keys, access tokens, private keys, or session cookies.
+- Personally identifying information: real names, email addresses, phone numbers, government IDs, physical addresses.
+- Internal-only identifiers that uniquely fingerprint a private system: non-public hostnames, internal service names, customer IDs, ticket numbers from private trackers.
+- Recommendations whose primary effect is to weaken security (disable auth, skip signature verification, suppress sandboxing) without a clearly scoped, defensive justification.
+
+Generate a single sanitized rewrite that removes or generalizes the violating content while preserving the underlying lesson. If no coherent lesson survives sanitization, flag the candidate as having no coherent rewrite — the user can still choose to keep the original or skip.
+
+**Soft concerns** — proceed with the candidate, flag the concern to the user before calling `propose`:
+
+- Framing that overgeneralizes from a single observation.
+- Vendor- or product-specific advice presented as universal.
+- Missing acknowledgement of an edge case the session itself surfaced.
+- Wording that could read as biased toward a specific team, person, or commercial product.
+- Impact that the agent cannot fully predict (e.g. action mutates shared state).
+
+#### Applying VIBE√
+
+- **Direct `propose` calls** (outside `/cq:reflect`) — run the check on the single candidate. If a hard finding exists, present both the original and the sanitized rewrite to the user and let them pick (or skip). If only a soft concern exists, present the concern for awareness before proceeding.
+- **Batch proposals via `/cq:reflect`** — see the `/cq:reflect` command for the batch presentation UX (three templates, provenance annotation). The underlying V/I/B/E classification rules are the same.
+
 ### Confirming Knowledge (`confirm`)
 
 Call `confirm` when a knowledge unit retrieved from a query proved correct during your session. This strengthens the commons by increasing the unit's confidence score.

--- a/sdk/go/prompts/SKILL.md
+++ b/sdk/go/prompts/SKILL.md
@@ -145,7 +145,7 @@ Before calling `propose`, evaluate every candidate against four safety dimension
 - **B — Biases**: Is the framing tied to a specific person, team, vendor, or commercial product in a way that isn't load-bearing for the lesson? Does it present one tool/approach as universally correct when the evidence supports only a narrow context?
 - **E — Edge cases**: Was the lesson learned from a single observation, or has it been validated across multiple cases? Are there obvious conditions (OS, version, scale, concurrency) under which it would not hold and that the candidate fails to acknowledge?
 
-Classify each finding into one of two tiers. Candidates are never dropped automatically — the user owns the final decision.
+Classify each finding into one of two tiers. The user owns the final decision on every candidate that reaches review — candidates are never silently dropped at that stage. Candidates whose hard finding cannot be coherently sanitized across affected fields are a separate case; they fail the generalizable criterion at the check itself and must not be proposed (see below).
 
 **Hard findings** — produce a sanitized rewrite before calling `propose`:
 

--- a/sdk/go/prompts/reflect.md
+++ b/sdk/go/prompts/reflect.md
@@ -63,15 +63,26 @@ For each candidate, assign:
 
 If the session contained no events meeting the above criteria, skip Steps 3–5 and follow the "no candidates" instruction in Step 6.
 
+### Step 2.5 — Run the VIBE√ safety check on each candidate
+
+Apply the VIBE√ safety check as defined in the cq skill against every candidate from Step 2. Classify each finding as clean, soft-concern, or hard-finding; for hard findings, generate the sanitized rewrite. Record the classification per candidate — Steps 3 and 6 use these results for presentation and the final summary.
+
+`/cq:reflect` never drops candidates automatically; the user owns the final decision about what to submit.
+
 ### Step 3 — Present candidates to the user
 
 Open with:
 
 ```
-I identified {N} potential learning candidates from this session worth sharing with the commons.
+I identified {N_total} potential learning candidates from this session.
+{N_hard} have hard concerns and are shown with both the original and a sanitized rewrite — pick which (if either) to store.
+{N_soft} have soft concerns flagged with ⚠️ for your awareness.
+{N_clean} passed the VIBE√ check cleanly.
 ```
 
-Present each candidate as a numbered entry:
+Present each candidate as a numbered entry. Use one of three templates depending on what Step 2.5 produced.
+
+**Clean candidate:**
 
 ```
 {N}. {summary}
@@ -82,11 +93,42 @@ Present each candidate as a numbered entry:
    Action: {action}
 ```
 
+**Soft-concern candidate** (add the `⚠️` line above the divider):
+
+```
+{N}. {summary}
+   Domains: {domain tags}
+   Relevance: {estimated_relevance}
+   ⚠️ {one-line concern}
+   ---
+   {detail}
+   Action: {action}
+```
+
+**Hard-finding candidate** (show both versions side by side, with the concern annotated):
+
+```
+{N}. {summary}
+   Domains: {domain tags}
+   Relevance: {estimated_relevance}
+   ⚠️ Hard concern: {one-line concern}
+   ---
+   Original:
+     {original detail}
+     Action: {original action}
+   Sanitized:
+     {rewritten detail}
+     Action: {rewritten action}
+```
+
+If the sanitized rewrite is not coherent (per the Step 2.5 fallback), substitute the Sanitized block with: `Sanitized: (no sanitized version possible — original would not generalize once stripped)`.
+
 After listing all candidates, ask:
 
 ```
 Reply with a number to approve, "skip {N}" to discard, or "edit {N}" to revise.
-You can also reply "all" to approve everything, or "none" to discard everything.
+For candidates with both an Original and a Sanitized version shown, use "{N} original" or "{N} sanitized" to choose which to store.
+You can also reply "all" to approve everything (sanitized version where applicable), or "none" to discard everything.
 ```
 
 ### Step 4 — Handle edits
@@ -123,12 +165,23 @@ Stored: {id} — "{summary}"
 ## Session Reflect Complete
 
 {approved} of {total} candidates proposed to cq.
-{skipped} skipped.
+{skipped} skipped by user.
+
+VIBE√ findings this session:
+- Hard concerns (candidates {numbers}): {one-line concern per candidate}
+- Soft concerns (candidates {numbers}): {one-line concern per candidate}
 
 IDs stored this session:
-- {id}: "{summary}"
+- {id}: "{summary}" [{clean | soft | sanitized | original}]
 - ...
 ```
+
+The bracketed annotation on each stored ID records the VIBE√ provenance of what was stored:
+
+- `clean` — no VIBE√ findings; stored as identified.
+- `soft` — soft concern present; stored as-is after the user weighed the flag.
+- `sanitized` — hard finding; the user picked the sanitized rewrite.
+- `original` — hard finding; the user explicitly picked the unmodified version.
 
 If no candidates were identified, display:
 
@@ -141,3 +194,4 @@ No shareable learnings identified in this session. Sessions with debugging, work
 - **Empty session** — If the session contained only routine tasks, say so and stop after Step 2.
 - **All candidates skipped** — Display the summary with 0 proposed.
 - **`propose` error** — Report the error inline for that candidate and continue with the next one. Do not abort.
+- **No coherent sanitized rewrite possible** — Present the original with the empty-rewrite note from Step 2.5. The user can still choose to keep the original locally or skip; do not silently drop the candidate.

--- a/sdk/go/prompts/reflect.md
+++ b/sdk/go/prompts/reflect.md
@@ -176,7 +176,8 @@ Stored: {id} — "{summary}"
 ```
 ## Session Reflect Complete
 
-{total} candidates identified. {excluded} dropped by VIBE√ (not generalizable; not presented).
+{total} candidates identified.
+{excluded} dropped by VIBE√ (not generalizable; not presented).
 {approved} proposed to cq. {skipped} skipped by user.
 
 VIBE√ findings this session:
@@ -189,7 +190,7 @@ IDs stored this session:
 - ...
 ```
 
-Omit any VIBE√ findings line whose category has no entries, and omit the `excluded` count sentence if zero.
+Always show the `{total} candidates identified.` line. Omit the `{excluded} dropped by VIBE√ ...` sentence when `{excluded}` is zero. Omit any VIBE√ findings bullet whose category has no entries.
 
 The bracketed annotation on each stored ID records the VIBE√ provenance of what was stored:
 

--- a/sdk/go/prompts/reflect.md
+++ b/sdk/go/prompts/reflect.md
@@ -65,27 +65,31 @@ If the session contained no events meeting the above criteria, skip Steps 3–5 
 
 ### Step 2.5 — Run the VIBE√ safety check on each candidate
 
-Apply the VIBE√ safety check as defined in the cq skill against every candidate from Step 2. Classify each finding as clean, soft-concern, or hard-finding; for hard findings, generate the sanitized rewrite. Record the classification per candidate — Steps 3 and 6 use these results for presentation and the final summary.
+Apply the VIBE√ safety check as defined in the cq skill against every candidate from Step 2. Classify each finding as clean, soft-concern, or hard-finding. For hard findings, generate the sanitized rewrite covering every `propose` field that could carry the violating content (`summary`, `detail`, `action`, `domains`, `languages`, `frameworks`, `pattern`). Record the classification per candidate — Steps 3 and 6 use these results for presentation and the final summary.
 
-`/cq:reflect` never drops candidates automatically; the user owns the final decision about what to submit.
+If a hard finding cannot be coherently sanitized, the candidate fails Step 2's generalizable criterion — drop it from the candidate list and record the exclusion in Step 6's summary. Do not present it. `/cq:reflect` never silently drops *presented* candidates; the user owns the final decision on every candidate that reaches Step 3.
 
 ### Step 3 — Present candidates to the user
 
 Open with:
 
 ```
-I identified {N_total} potential learning candidates from this session.
-{N_hard} have hard concerns and are shown with both the original and a sanitized rewrite — pick which (if either) to store.
-{N_soft} have soft concerns flagged with ⚠️ for your awareness.
-{N_clean} passed the VIBE√ check cleanly.
+cq identified {total} potential learning candidates from this session...
+
+{hard} have hard concerns and are shown with both the original and a sanitized rewrite — pick which (if either) to store.
+{soft} have soft concerns flagged with ⚠️ for your awareness.
+{clean} passed the VIBE√ check cleanly.
 ```
 
-Present each candidate as a numbered entry. Use one of three templates depending on what Step 2.5 produced.
+Omit any count line whose value is zero.
+
+Present each candidate as a numbered entry. Use one of three templates depending on what Step 2.5 produced. Every template has a blank line after the `{N}. {summary}` header so the metadata block is visually distinct.
 
 **Clean candidate:**
 
 ```
 {N}. {summary}
+
    Domains: {domain tags}
    Relevance: {estimated_relevance}
    ---
@@ -93,42 +97,50 @@ Present each candidate as a numbered entry. Use one of three templates depending
    Action: {action}
 ```
 
-**Soft-concern candidate** (add the `⚠️` line above the divider):
+**Soft-concern candidate** (add the `⚠️` line as the first line of the metadata block, above `Domains`):
 
 ```
 {N}. {summary}
-   Domains: {domain tags}
-   Relevance: {estimated_relevance}
+
    ⚠️ {one-line concern}
+   Domains: {domain tags}
+   Relevance: {estimated_relevance}
    ---
    {detail}
    Action: {action}
 ```
 
-**Hard-finding candidate** (show both versions side by side, with the concern annotated):
+**Hard-finding candidate.** The header `summary` and `Domains` use the sanitized values — the header never shows hard-finding content. The Original block shows the full original fields (summary, domains, detail, action). The Sanitized block shows only fields that differ from the header, i.e. detail and action.
 
 ```
-{N}. {summary}
-   Domains: {domain tags}
-   Relevance: {estimated_relevance}
+{N}. {sanitized summary}
+
    ⚠️ Hard concern: {one-line concern}
+   Domains: {sanitized domain tags}
+   Relevance: {estimated_relevance}
    ---
    Original:
-     {original detail}
+     Summary: {original summary}
+     Domains: {original domain tags}
+     Detail: {original detail}
      Action: {original action}
    Sanitized:
-     {rewritten detail}
-     Action: {rewritten action}
+     Detail: {sanitized detail}
+     Action: {sanitized action}
 ```
 
-If the sanitized rewrite is not coherent (per the Step 2.5 fallback), substitute the Sanitized block with: `Sanitized: (no sanitized version possible — original would not generalize once stripped)`.
-
-After listing all candidates, ask:
+After listing all candidates, show the command reference:
 
 ```
-Reply with a number to approve, "skip {N}" to discard, or "edit {N}" to revise.
-For candidates with both an Original and a Sanitized version shown, use "{N} original" or "{N} sanitized" to choose which to store.
-You can also reply "all" to approve everything (sanitized version where applicable), or "none" to discard everything.
+Commands:
+  N              approve (sanitized version for hard-findings)
+  N original     approve original instead (hard-findings only)
+  edit N         revise before storing
+  skip N         discard
+  all            approve every candidate's default
+  none           discard everything
+
+Combine with commas: e.g. "1, 3 original, skip 2" applies each command in order.
 ```
 
 ### Step 4 — Handle edits
@@ -164,17 +176,20 @@ Stored: {id} — "{summary}"
 ```
 ## Session Reflect Complete
 
-{approved} of {total} candidates proposed to cq.
-{skipped} skipped by user.
+{total} candidates identified. {excluded} dropped by VIBE√ (not generalizable; not presented).
+{approved} proposed to cq. {skipped} skipped by user.
 
 VIBE√ findings this session:
 - Hard concerns (candidates {numbers}): {one-line concern per candidate}
 - Soft concerns (candidates {numbers}): {one-line concern per candidate}
+- Excluded (not presented): {one-line reason per excluded candidate}
 
 IDs stored this session:
 - {id}: "{summary}" [{clean | soft | sanitized | original}]
 - ...
 ```
+
+Omit any VIBE√ findings line whose category has no entries, and omit the `excluded` count sentence if zero.
 
 The bracketed annotation on each stored ID records the VIBE√ provenance of what was stored:
 
@@ -194,4 +209,3 @@ No shareable learnings identified in this session. Sessions with debugging, work
 - **Empty session** — If the session contained only routine tasks, say so and stop after Step 2.
 - **All candidates skipped** — Display the summary with 0 proposed.
 - **`propose` error** — Report the error inline for that candidate and continue with the next one. Do not abort.
-- **No coherent sanitized rewrite possible** — Present the original with the empty-rewrite note from Step 2.5. The user can still choose to keep the original locally or skip; do not silently drop the candidate.

--- a/sdk/python/src/cq/prompts/SKILL.md
+++ b/sdk/python/src/cq/prompts/SKILL.md
@@ -154,7 +154,9 @@ Classify each finding into one of two tiers. Candidates are never dropped automa
 - Internal-only identifiers that uniquely fingerprint a private system: non-public hostnames, internal service names, customer IDs, ticket numbers from private trackers.
 - Recommendations whose primary effect is to weaken security (disable auth, skip signature verification, suppress sandboxing) without a clearly scoped, defensive justification.
 
-Generate a single sanitized rewrite that removes or generalizes the violating content while preserving the underlying lesson. If no coherent lesson survives sanitization, flag the candidate as having no coherent rewrite — the user can still choose to keep the original or skip.
+Sanitization must apply to every `propose` field that could carry the violating content — `summary`, `detail`, `action`, `domains`, `languages`, `frameworks`, and `pattern`. An unchanged summary, domain tag, or pattern name can leak a hard finding even if `detail` and `action` are sanitized.
+
+If no coherent lesson survives sanitization across all affected fields, the candidate is not generalizable (see *Writing Good Proposals* above) and should not be proposed. Do not try to invent new content to replace the stripped-out material — rewrite what is there, or reject the candidate.
 
 **Soft concerns** — proceed with the candidate, flag the concern to the user before calling `propose`:
 

--- a/sdk/python/src/cq/prompts/SKILL.md
+++ b/sdk/python/src/cq/prompts/SKILL.md
@@ -136,6 +136,39 @@ Provide all three insight fields:
 - **detail** — Fuller explanation with enough context to understand the issue. Include a timestamp and source where possible.
 - **action** — Concrete instruction on what to do about it. Prefer principle + verification method over exact values.
 
+#### VIBE√ safety check
+
+Before calling `propose`, evaluate every candidate against four safety dimensions. This applies to all propose calls — those triggered by `/cq:reflect` and direct proposes made while working on a task.
+
+- **V — Vulnerabilities**: Does the candidate contain or reveal credentials, API keys, tokens, internal hostnames, IP addresses, file paths that disclose user identity, or any other secret? Does the action it recommends introduce a security risk if applied blindly (e.g. disabling auth checks, weakening TLS, executing untrusted input)?
+- **I — Impact**: If another agent applied this candidate verbatim in an unrelated codebase, what is the worst plausible outcome? Could it cause data loss, production incidents, or cascading failures?
+- **B — Biases**: Is the framing tied to a specific person, team, vendor, or commercial product in a way that isn't load-bearing for the lesson? Does it present one tool/approach as universally correct when the evidence supports only a narrow context?
+- **E — Edge cases**: Was the lesson learned from a single observation, or has it been validated across multiple cases? Are there obvious conditions (OS, version, scale, concurrency) under which it would not hold and that the candidate fails to acknowledge?
+
+Classify each finding into one of two tiers. Candidates are never dropped automatically — the user owns the final decision.
+
+**Hard findings** — produce a sanitized rewrite before calling `propose`:
+
+- Literal credentials, API keys, access tokens, private keys, or session cookies.
+- Personally identifying information: real names, email addresses, phone numbers, government IDs, physical addresses.
+- Internal-only identifiers that uniquely fingerprint a private system: non-public hostnames, internal service names, customer IDs, ticket numbers from private trackers.
+- Recommendations whose primary effect is to weaken security (disable auth, skip signature verification, suppress sandboxing) without a clearly scoped, defensive justification.
+
+Generate a single sanitized rewrite that removes or generalizes the violating content while preserving the underlying lesson. If no coherent lesson survives sanitization, flag the candidate as having no coherent rewrite — the user can still choose to keep the original or skip.
+
+**Soft concerns** — proceed with the candidate, flag the concern to the user before calling `propose`:
+
+- Framing that overgeneralizes from a single observation.
+- Vendor- or product-specific advice presented as universal.
+- Missing acknowledgement of an edge case the session itself surfaced.
+- Wording that could read as biased toward a specific team, person, or commercial product.
+- Impact that the agent cannot fully predict (e.g. action mutates shared state).
+
+#### Applying VIBE√
+
+- **Direct `propose` calls** (outside `/cq:reflect`) — run the check on the single candidate. If a hard finding exists, present both the original and the sanitized rewrite to the user and let them pick (or skip). If only a soft concern exists, present the concern for awareness before proceeding.
+- **Batch proposals via `/cq:reflect`** — see the `/cq:reflect` command for the batch presentation UX (three templates, provenance annotation). The underlying V/I/B/E classification rules are the same.
+
 ### Confirming Knowledge (`confirm`)
 
 Call `confirm` when a knowledge unit retrieved from a query proved correct during your session. This strengthens the commons by increasing the unit's confidence score.

--- a/sdk/python/src/cq/prompts/SKILL.md
+++ b/sdk/python/src/cq/prompts/SKILL.md
@@ -145,7 +145,7 @@ Before calling `propose`, evaluate every candidate against four safety dimension
 - **B — Biases**: Is the framing tied to a specific person, team, vendor, or commercial product in a way that isn't load-bearing for the lesson? Does it present one tool/approach as universally correct when the evidence supports only a narrow context?
 - **E — Edge cases**: Was the lesson learned from a single observation, or has it been validated across multiple cases? Are there obvious conditions (OS, version, scale, concurrency) under which it would not hold and that the candidate fails to acknowledge?
 
-Classify each finding into one of two tiers. Candidates are never dropped automatically — the user owns the final decision.
+Classify each finding into one of two tiers. The user owns the final decision on every candidate that reaches review — candidates are never silently dropped at that stage. Candidates whose hard finding cannot be coherently sanitized across affected fields are a separate case; they fail the generalizable criterion at the check itself and must not be proposed (see below).
 
 **Hard findings** — produce a sanitized rewrite before calling `propose`:
 

--- a/sdk/python/src/cq/prompts/reflect.md
+++ b/sdk/python/src/cq/prompts/reflect.md
@@ -63,15 +63,26 @@ For each candidate, assign:
 
 If the session contained no events meeting the above criteria, skip Steps 3–5 and follow the "no candidates" instruction in Step 6.
 
+### Step 2.5 — Run the VIBE√ safety check on each candidate
+
+Apply the VIBE√ safety check as defined in the cq skill against every candidate from Step 2. Classify each finding as clean, soft-concern, or hard-finding; for hard findings, generate the sanitized rewrite. Record the classification per candidate — Steps 3 and 6 use these results for presentation and the final summary.
+
+`/cq:reflect` never drops candidates automatically; the user owns the final decision about what to submit.
+
 ### Step 3 — Present candidates to the user
 
 Open with:
 
 ```
-I identified {N} potential learning candidates from this session worth sharing with the commons.
+I identified {N_total} potential learning candidates from this session.
+{N_hard} have hard concerns and are shown with both the original and a sanitized rewrite — pick which (if either) to store.
+{N_soft} have soft concerns flagged with ⚠️ for your awareness.
+{N_clean} passed the VIBE√ check cleanly.
 ```
 
-Present each candidate as a numbered entry:
+Present each candidate as a numbered entry. Use one of three templates depending on what Step 2.5 produced.
+
+**Clean candidate:**
 
 ```
 {N}. {summary}
@@ -82,11 +93,42 @@ Present each candidate as a numbered entry:
    Action: {action}
 ```
 
+**Soft-concern candidate** (add the `⚠️` line above the divider):
+
+```
+{N}. {summary}
+   Domains: {domain tags}
+   Relevance: {estimated_relevance}
+   ⚠️ {one-line concern}
+   ---
+   {detail}
+   Action: {action}
+```
+
+**Hard-finding candidate** (show both versions side by side, with the concern annotated):
+
+```
+{N}. {summary}
+   Domains: {domain tags}
+   Relevance: {estimated_relevance}
+   ⚠️ Hard concern: {one-line concern}
+   ---
+   Original:
+     {original detail}
+     Action: {original action}
+   Sanitized:
+     {rewritten detail}
+     Action: {rewritten action}
+```
+
+If the sanitized rewrite is not coherent (per the Step 2.5 fallback), substitute the Sanitized block with: `Sanitized: (no sanitized version possible — original would not generalize once stripped)`.
+
 After listing all candidates, ask:
 
 ```
 Reply with a number to approve, "skip {N}" to discard, or "edit {N}" to revise.
-You can also reply "all" to approve everything, or "none" to discard everything.
+For candidates with both an Original and a Sanitized version shown, use "{N} original" or "{N} sanitized" to choose which to store.
+You can also reply "all" to approve everything (sanitized version where applicable), or "none" to discard everything.
 ```
 
 ### Step 4 — Handle edits
@@ -123,12 +165,23 @@ Stored: {id} — "{summary}"
 ## Session Reflect Complete
 
 {approved} of {total} candidates proposed to cq.
-{skipped} skipped.
+{skipped} skipped by user.
+
+VIBE√ findings this session:
+- Hard concerns (candidates {numbers}): {one-line concern per candidate}
+- Soft concerns (candidates {numbers}): {one-line concern per candidate}
 
 IDs stored this session:
-- {id}: "{summary}"
+- {id}: "{summary}" [{clean | soft | sanitized | original}]
 - ...
 ```
+
+The bracketed annotation on each stored ID records the VIBE√ provenance of what was stored:
+
+- `clean` — no VIBE√ findings; stored as identified.
+- `soft` — soft concern present; stored as-is after the user weighed the flag.
+- `sanitized` — hard finding; the user picked the sanitized rewrite.
+- `original` — hard finding; the user explicitly picked the unmodified version.
 
 If no candidates were identified, display:
 
@@ -141,3 +194,4 @@ No shareable learnings identified in this session. Sessions with debugging, work
 - **Empty session** — If the session contained only routine tasks, say so and stop after Step 2.
 - **All candidates skipped** — Display the summary with 0 proposed.
 - **`propose` error** — Report the error inline for that candidate and continue with the next one. Do not abort.
+- **No coherent sanitized rewrite possible** — Present the original with the empty-rewrite note from Step 2.5. The user can still choose to keep the original locally or skip; do not silently drop the candidate.

--- a/sdk/python/src/cq/prompts/reflect.md
+++ b/sdk/python/src/cq/prompts/reflect.md
@@ -176,7 +176,8 @@ Stored: {id} — "{summary}"
 ```
 ## Session Reflect Complete
 
-{total} candidates identified. {excluded} dropped by VIBE√ (not generalizable; not presented).
+{total} candidates identified.
+{excluded} dropped by VIBE√ (not generalizable; not presented).
 {approved} proposed to cq. {skipped} skipped by user.
 
 VIBE√ findings this session:
@@ -189,7 +190,7 @@ IDs stored this session:
 - ...
 ```
 
-Omit any VIBE√ findings line whose category has no entries, and omit the `excluded` count sentence if zero.
+Always show the `{total} candidates identified.` line. Omit the `{excluded} dropped by VIBE√ ...` sentence when `{excluded}` is zero. Omit any VIBE√ findings bullet whose category has no entries.
 
 The bracketed annotation on each stored ID records the VIBE√ provenance of what was stored:
 

--- a/sdk/python/src/cq/prompts/reflect.md
+++ b/sdk/python/src/cq/prompts/reflect.md
@@ -65,27 +65,31 @@ If the session contained no events meeting the above criteria, skip Steps 3–5 
 
 ### Step 2.5 — Run the VIBE√ safety check on each candidate
 
-Apply the VIBE√ safety check as defined in the cq skill against every candidate from Step 2. Classify each finding as clean, soft-concern, or hard-finding; for hard findings, generate the sanitized rewrite. Record the classification per candidate — Steps 3 and 6 use these results for presentation and the final summary.
+Apply the VIBE√ safety check as defined in the cq skill against every candidate from Step 2. Classify each finding as clean, soft-concern, or hard-finding. For hard findings, generate the sanitized rewrite covering every `propose` field that could carry the violating content (`summary`, `detail`, `action`, `domains`, `languages`, `frameworks`, `pattern`). Record the classification per candidate — Steps 3 and 6 use these results for presentation and the final summary.
 
-`/cq:reflect` never drops candidates automatically; the user owns the final decision about what to submit.
+If a hard finding cannot be coherently sanitized, the candidate fails Step 2's generalizable criterion — drop it from the candidate list and record the exclusion in Step 6's summary. Do not present it. `/cq:reflect` never silently drops *presented* candidates; the user owns the final decision on every candidate that reaches Step 3.
 
 ### Step 3 — Present candidates to the user
 
 Open with:
 
 ```
-I identified {N_total} potential learning candidates from this session.
-{N_hard} have hard concerns and are shown with both the original and a sanitized rewrite — pick which (if either) to store.
-{N_soft} have soft concerns flagged with ⚠️ for your awareness.
-{N_clean} passed the VIBE√ check cleanly.
+cq identified {total} potential learning candidates from this session...
+
+{hard} have hard concerns and are shown with both the original and a sanitized rewrite — pick which (if either) to store.
+{soft} have soft concerns flagged with ⚠️ for your awareness.
+{clean} passed the VIBE√ check cleanly.
 ```
 
-Present each candidate as a numbered entry. Use one of three templates depending on what Step 2.5 produced.
+Omit any count line whose value is zero.
+
+Present each candidate as a numbered entry. Use one of three templates depending on what Step 2.5 produced. Every template has a blank line after the `{N}. {summary}` header so the metadata block is visually distinct.
 
 **Clean candidate:**
 
 ```
 {N}. {summary}
+
    Domains: {domain tags}
    Relevance: {estimated_relevance}
    ---
@@ -93,42 +97,50 @@ Present each candidate as a numbered entry. Use one of three templates depending
    Action: {action}
 ```
 
-**Soft-concern candidate** (add the `⚠️` line above the divider):
+**Soft-concern candidate** (add the `⚠️` line as the first line of the metadata block, above `Domains`):
 
 ```
 {N}. {summary}
-   Domains: {domain tags}
-   Relevance: {estimated_relevance}
+
    ⚠️ {one-line concern}
+   Domains: {domain tags}
+   Relevance: {estimated_relevance}
    ---
    {detail}
    Action: {action}
 ```
 
-**Hard-finding candidate** (show both versions side by side, with the concern annotated):
+**Hard-finding candidate.** The header `summary` and `Domains` use the sanitized values — the header never shows hard-finding content. The Original block shows the full original fields (summary, domains, detail, action). The Sanitized block shows only fields that differ from the header, i.e. detail and action.
 
 ```
-{N}. {summary}
-   Domains: {domain tags}
-   Relevance: {estimated_relevance}
+{N}. {sanitized summary}
+
    ⚠️ Hard concern: {one-line concern}
+   Domains: {sanitized domain tags}
+   Relevance: {estimated_relevance}
    ---
    Original:
-     {original detail}
+     Summary: {original summary}
+     Domains: {original domain tags}
+     Detail: {original detail}
      Action: {original action}
    Sanitized:
-     {rewritten detail}
-     Action: {rewritten action}
+     Detail: {sanitized detail}
+     Action: {sanitized action}
 ```
 
-If the sanitized rewrite is not coherent (per the Step 2.5 fallback), substitute the Sanitized block with: `Sanitized: (no sanitized version possible — original would not generalize once stripped)`.
-
-After listing all candidates, ask:
+After listing all candidates, show the command reference:
 
 ```
-Reply with a number to approve, "skip {N}" to discard, or "edit {N}" to revise.
-For candidates with both an Original and a Sanitized version shown, use "{N} original" or "{N} sanitized" to choose which to store.
-You can also reply "all" to approve everything (sanitized version where applicable), or "none" to discard everything.
+Commands:
+  N              approve (sanitized version for hard-findings)
+  N original     approve original instead (hard-findings only)
+  edit N         revise before storing
+  skip N         discard
+  all            approve every candidate's default
+  none           discard everything
+
+Combine with commas: e.g. "1, 3 original, skip 2" applies each command in order.
 ```
 
 ### Step 4 — Handle edits
@@ -164,17 +176,20 @@ Stored: {id} — "{summary}"
 ```
 ## Session Reflect Complete
 
-{approved} of {total} candidates proposed to cq.
-{skipped} skipped by user.
+{total} candidates identified. {excluded} dropped by VIBE√ (not generalizable; not presented).
+{approved} proposed to cq. {skipped} skipped by user.
 
 VIBE√ findings this session:
 - Hard concerns (candidates {numbers}): {one-line concern per candidate}
 - Soft concerns (candidates {numbers}): {one-line concern per candidate}
+- Excluded (not presented): {one-line reason per excluded candidate}
 
 IDs stored this session:
 - {id}: "{summary}" [{clean | soft | sanitized | original}]
 - ...
 ```
+
+Omit any VIBE√ findings line whose category has no entries, and omit the `excluded` count sentence if zero.
 
 The bracketed annotation on each stored ID records the VIBE√ provenance of what was stored:
 
@@ -194,4 +209,3 @@ No shareable learnings identified in this session. Sessions with debugging, work
 - **Empty session** — If the session contained only routine tasks, say so and stop after Step 2.
 - **All candidates skipped** — Display the summary with 0 proposed.
 - **`propose` error** — Report the error inline for that candidate and continue with the next one. Do not abort.
-- **No coherent sanitized rewrite possible** — Present the original with the empty-rewrite note from Step 2.5. The user can still choose to keep the original locally or skip; do not silently drop the candidate.


### PR DESCRIPTION
## Summary

Adds a VIBE√ (**V**ulnerabilities, **I**mpact, **B**iases, **E**dge cases) safety check that agents apply before every `propose` call, addressing #240.

The check lives in [`plugins/cq/skills/cq/SKILL.md`](plugins/cq/skills/cq/SKILL.md) so it applies universally — both to direct `propose` calls the agent makes during a task and to batch proposals triggered by `/cq:reflect`. This is a **markdown-only change**.

## Shape of the change

- **`SKILL.md` → `Proposing Knowledge (propose)` section** gets a new `VIBE√ safety check` subsection: the four dimensions, hard/soft classification, and the sanitized-rewrite rule. Sanitization must cover every `propose` field that could carry the violating content — `summary`, `detail`, `action`, `domains`, `languages`, `frameworks`, and `pattern` — since an unchanged summary or domain tag can leak a hard finding even when detail and action are sanitized.
- **Direct `propose` calls** — agent runs the check on the single candidate. Hard finding → present original + sanitized to user, user picks (or skips). Soft concern → flag for awareness, proceed.
- **`/cq:reflect` Step 2.5** — runs VIBE√ per candidate and records the classification. If a hard finding cannot be coherently sanitized across affected fields, the candidate fails Step 2's generalizable criterion and is excluded from the presented list (recorded in Step 6's summary). Candidates that reach Step 3 are never silently dropped — the user owns every final decision there.
- **Step 3 presentation** — three templates (clean / soft / hard). Blank line after the `{N}. {summary}` header separates it from the metadata block. The `⚠️` warning sits at the top of the metadata block above `Domains`. For hard-finding candidates the header `summary` and `Domains` already use the sanitized values (so nothing unchanged can leak); the Original block shows the full original fields, and the Sanitized block shows only fields that differ from the header (detail, action).
- **Reply UX** — a Commands table (`N`, `N original`, `edit N`, `skip N`, `all`, `none`) with comma-separated multi-selection support (e.g. `1, 3 original, skip 2`).
- **Step 6 summary** — records VIBE√ provenance per stored ID (`clean | soft | sanitized | original`), plus an `{excluded}` count sentence and an "Excluded (not presented)" findings line for candidates dropped at Step 2.5. Count placeholders are standardised on an unprefixed form (`{total}`, `{hard}`, `{soft}`, `{clean}`, `{approved}`, `{skipped}`, `{excluded}`).
- **SDK prompt copies synced** via `make sync-prompts` — propagates the SKILL.md/reflect.md changes into `sdk/go/prompts/` and `sdk/python/src/cq/prompts/` so SDK consumers see the canonical source.

## Discussion points

1. **V/I/B/E in user-facing flag?** Currently no — user sees `⚠️ {concern}` without categorisation. Trade-off: cleaner output vs. easier triage when candidate lists get long.
2. **Richer review UI?** Terminal output assumed. Larger candidate sets with mixed clean/soft/hard could benefit from filtering and side-by-side comparison.
3. **Hard-finding list framing.** Illustrative ("real names, email addresses, ...") rather than tied to specific regulated categories (GDPR special categories, HIPAA PHI, etc.). Sanity check welcome.

*(Original point 4 — "Never drop posture" — resolved during review: no-coherent-sanitization candidates are now excluded at Step 2.5 as failures of Step 2's generalizable criterion rather than presented with an empty-rewrite fallback.)*

## Test plan

- [ ] `make lint` (includes `check-prompts-sync`, which verifies the SDK prompt copies match the plugin source).
- [ ] `make test`
- [ ] Copy the changed files into the local marketplace + plugin cache, restart Claude Code, and exercise both paths:

```bash
cp plugins/cq/commands/reflect.md ~/.claude/plugins/marketplaces/cq/plugins/cq/commands/reflect.md
cp plugins/cq/skills/cq/SKILL.md  ~/.claude/plugins/marketplaces/cq/plugins/cq/skills/cq/SKILL.md
cp plugins/cq/commands/reflect.md ~/.claude/plugins/cache/cq/cq/0.7.5/commands/reflect.md
cp plugins/cq/skills/cq/SKILL.md  ~/.claude/plugins/cache/cq/cq/0.7.5/skills/cq/SKILL.md
```

- [ ] **Direct `propose` path.** Trigger a non-`/cq:reflect` proposal by working through a task where the agent discovers a non-obvious insight (e.g. undocumented API behaviour). Confirm the agent applies VIBE√ before the `propose` call and presents original + sanitized for any hard finding.
- [ ] **Batch `/cq:reflect` path.** Run `/cq:reflect` with at least one clean, one soft-concern, and one hard-finding candidate. Confirm all three templates render (warning above Domains; hard-finding header uses sanitized values), the Commands table supports comma-separated multi-selection (e.g. `1, 3 original, skip 2`), provenance annotation (`clean | soft | sanitized | original`) lands in the final summary, and `propose` is called for approved candidates only.
- [ ] **Step 2.5 exclusion path.** Confirm that a candidate with a hard finding that cannot be coherently sanitized is excluded from the presented list and recorded in the Step 6 "Excluded (not presented)" line rather than being shown.
- [ ] Resolve the remaining discussion points above before treating this as final.