### PR TITLE
Add pattern as a soft-boost filter on query across the stack

### DIFF
--- a/cli/cmd/query.go
+++ b/cli/cmd/query.go
@@ -15,6 +15,7 @@ func NewQueryCmd() *cobra.Command {
 		domains    []string
 		languages  []string
 		frameworks []string
+		pattern    string
 		limit      int
 		format     string
 	)
@@ -40,6 +41,7 @@ func NewQueryCmd() *cobra.Command {
 				Domains:    domains,
 				Languages:  languages,
 				Frameworks: frameworks,
+				Pattern:    pattern,
 				Limit:      limit,
 			}
 
@@ -75,6 +77,7 @@ func NewQueryCmd() *cobra.Command {
 	cmd.Flags().StringArrayVar(&domains, "domain", nil, "Domain tags to search (required, repeatable)")
 	cmd.Flags().StringArrayVar(&languages, "language", nil, "Filter by programming language (repeatable)")
 	cmd.Flags().StringArrayVar(&frameworks, "framework", nil, "Filter by framework (repeatable)")
+	cmd.Flags().StringVar(&pattern, "pattern", "", "Filter by pattern")
 	cmd.Flags().IntVar(&limit, "limit", 5, "Maximum results")
 	cmd.Flags().StringVar(&format, "format", "text", "Output format: text or json")
 	_ = cmd.MarkFlagRequired("domain")

--- a/cli/cmd/query_test.go
+++ b/cli/cmd/query_test.go
@@ -2,9 +2,12 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	cq "github.com/mozilla-ai/cq/sdk/go"
 )
 
 func TestQueryRepeatedDomainFlags(t *testing.T) {
@@ -127,24 +130,44 @@ func TestQueryUnsupportedFormat(t *testing.T) {
 func TestQueryPatternFlag(t *testing.T) {
 	testSetup(t)
 
-	propose := NewProposeCmd()
-	propose.SetArgs([]string{
+	// Seed two KUs on the same domain so domain match alone cannot decide ranking.
+	// Only one carries the pattern; the other is a plain domain match.
+	// The plain KU is inserted first so a "pattern flag is silently dropped" regression
+	// would leave it ranked first by insertion order, distinguishing it from the correct
+	// behavior where the pattern boost lifts the matching KU above the plain one.
+	proposePlain := NewProposeCmd()
+	proposePlain.SetArgs([]string{
+		"--summary", "plain insight",
+		"--detail", "d",
+		"--action", "a",
+		"--domain", "api",
+	})
+	require.NoError(t, proposePlain.Execute())
+
+	proposeMatch := NewProposeCmd()
+	proposeMatch.SetArgs([]string{
 		"--summary", "pattern insight",
 		"--detail", "d",
 		"--action", "a",
 		"--domain", "api",
 		"--pattern", "api-client",
 	})
-	require.NoError(t, propose.Execute())
+	require.NoError(t, proposeMatch.Execute())
 
+	// Use JSON output so the ranking order is observable as an array index.
 	query := NewQueryCmd()
 	var buf bytes.Buffer
 	query.SetOut(&buf)
 	query.SetArgs([]string{
 		"--domain", "api",
 		"--pattern", "api-client",
-		"--format", "text",
+		"--format", "json",
 	})
 	require.NoError(t, query.Execute())
-	require.Contains(t, buf.String(), "pattern insight")
+
+	var units []cq.KnowledgeUnit
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &units))
+	require.Len(t, units, 2)
+	require.Equal(t, "pattern insight", units[0].Insight.Summary,
+		"the unit with matching pattern should rank first when --pattern is threaded into QueryParams")
 }

--- a/cli/cmd/query_test.go
+++ b/cli/cmd/query_test.go
@@ -123,3 +123,28 @@ func TestQueryUnsupportedFormat(t *testing.T) {
 	query.SetArgs([]string{"--domain", "api", "--format", "xml"})
 	require.Error(t, query.Execute())
 }
+
+func TestQueryPatternFlag(t *testing.T) {
+	testSetup(t)
+
+	propose := NewProposeCmd()
+	propose.SetArgs([]string{
+		"--summary", "pattern insight",
+		"--detail", "d",
+		"--action", "a",
+		"--domain", "api",
+		"--pattern", "api-client",
+	})
+	require.NoError(t, propose.Execute())
+
+	query := NewQueryCmd()
+	var buf bytes.Buffer
+	query.SetOut(&buf)
+	query.SetArgs([]string{
+		"--domain", "api",
+		"--pattern", "api-client",
+		"--format", "text",
+	})
+	require.NoError(t, query.Execute())
+	require.Contains(t, buf.String(), "pattern insight")
+}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -31,4 +31,4 @@ require (
 )
 
 // Monorepo: uncomment to use the local SDK during development.
-// replace github.com/mozilla-ai/cq/sdk/go => ../sdk/go
+replace github.com/mozilla-ai/cq/sdk/go => ../sdk/go

--- a/cli/mcpserver/e2e_test.go
+++ b/cli/mcpserver/e2e_test.go
@@ -106,3 +106,70 @@ func TestE2EProposeQueryConfirmFlagStatus(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(statusText), &stats))
 	require.Equal(t, 1, stats.TotalCount)
 }
+
+// TestE2EPatternBoost verifies that the MCP query tool threads the pattern filter through to
+// scoring so a pattern-matching unit ranks above an otherwise-equivalent plain unit. The plain
+// unit is inserted first so insertion-order tiebreaking would rank it first if the pattern boost
+// were silently dropped anywhere in the propose -> store -> query path.
+func TestE2EPatternBoost(t *testing.T) {
+	realClient := newSDKClient(t)
+	srv := mcpserver.New(realClient, "test")
+	c := newMCPTestClient(t, srv)
+	ctx := context.Background()
+
+	plainResp, err := c.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "propose",
+			Arguments: map[string]any{
+				"summary": "plain",
+				"detail":  "no pattern",
+				"action":  "noop",
+				"domains": []any{"api"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, plainResp.IsError)
+
+	var plain cq.KnowledgeUnit
+	plainText := plainResp.Content[0].(mcp.TextContent).Text
+	require.NoError(t, json.Unmarshal([]byte(plainText), &plain))
+
+	matchResp, err := c.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "propose",
+			Arguments: map[string]any{
+				"summary": "match",
+				"detail":  "with pattern",
+				"action":  "noop",
+				"domains": []any{"api"},
+				"pattern": "api-client",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, matchResp.IsError)
+
+	var match cq.KnowledgeUnit
+	matchText := matchResp.Content[0].(mcp.TextContent).Text
+	require.NoError(t, json.Unmarshal([]byte(matchText), &match))
+
+	queryResp, err := c.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "query",
+			Arguments: map[string]any{
+				"domains": []any{"api"},
+				"pattern": "api-client",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, queryResp.IsError)
+
+	var units []cq.KnowledgeUnit
+	queryText := queryResp.Content[0].(mcp.TextContent).Text
+	require.NoError(t, json.Unmarshal([]byte(queryText), &units))
+	require.Len(t, units, 2)
+	require.Equal(t, match.ID, units[0].ID, "the pattern-matching unit must rank above the plain unit")
+	require.Equal(t, plain.ID, units[1].ID)
+}

--- a/cli/mcpserver/query.go
+++ b/cli/mcpserver/query.go
@@ -35,6 +35,9 @@ func QueryTool() mcp.Tool {
 			mcp.Description("Filter by frameworks."),
 			mcp.WithStringItems(),
 		),
+		mcp.WithString("pattern",
+			mcp.Description("Filter by pattern."),
+		),
 		mcp.WithNumber("limit",
 			mcp.Description("Maximum results to return (default 5, max 50)."),
 		),
@@ -63,6 +66,7 @@ func (s *Server) HandleQuery(ctx context.Context, req mcp.CallToolRequest) (*mcp
 		Domains:    domains,
 		Languages:  req.GetStringSlice("languages", nil),
 		Frameworks: req.GetStringSlice("frameworks", nil),
+		Pattern:    req.GetString("pattern", ""),
 		Limit:      limit,
 	}
 

--- a/cli/mcpserver/query_test.go
+++ b/cli/mcpserver/query_test.go
@@ -51,6 +51,31 @@ func TestHandleQuery(t *testing.T) {
 		require.Len(t, units, 1)
 	})
 
+	t.Run("passes pattern through to QueryParams", func(t *testing.T) {
+		t.Parallel()
+
+		var got cq.QueryParams
+		s := New(&mockClient{
+			queryFn: func(_ context.Context, params cq.QueryParams) (cq.QueryResult, error) {
+				got = params
+				return cq.QueryResult{}, nil
+			},
+		}, "test")
+
+		result, err := s.HandleQuery(context.Background(), mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name: "query",
+				Arguments: map[string]any{
+					"domains": []any{"api"},
+					"pattern": "api-client",
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+		require.Equal(t, "api-client", got.Pattern)
+	})
+
 	t.Run("errors when domains missing", func(t *testing.T) {
 		t.Parallel()
 

--- a/plugins/cq/skills/cq/SKILL.md
+++ b/plugins/cq/skills/cq/SKILL.md
@@ -65,7 +65,7 @@ Do not query cq for:
 
 Choose domain tags that capture the technology, layer, and integration point. Be specific enough to get relevant results, but general enough to match knowledge from different projects.
 
-Both `query` and `propose` use the same plural-array keys for `domains`, `languages`, and `frameworks`. Each is a flat top-level argument; there is no `context` wrapper.
+Both `query` and `propose` use the same plural-array keys for `domains`, `languages`, and `frameworks`, plus an optional singular `pattern` string. Each is a flat top-level argument; there is no `context` wrapper.
 
 | Scenario | `domains` | other call args |
 |----------|-----------|------------------|

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -343,6 +343,10 @@ func (c *Client) Query(ctx context.Context, params QueryParams) (QueryResult, er
 		qOpts = append(qOpts, withFramework(f))
 	}
 
+	if params.Pattern != "" {
+		qOpts = append(qOpts, withPattern(params.Pattern))
+	}
+
 	storeResult, err := c.store.query(qOpts...)
 	if err != nil {
 		return QueryResult{}, fmt.Errorf("querying store: %w", err)

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -704,3 +704,28 @@ func TestStatusIgnoresLocalTierFromRemote(t *testing.T) {
 	// Total is local (1) + private (4) + public (1) = 6. The remote's "local: 1" is excluded.
 	require.Equal(t, 6, stats.TotalCount)
 }
+
+func TestClientQueryPassesPatternToStore(t *testing.T) {
+	c := newTestClient(t)
+
+	_, err := c.Propose(context.Background(), ProposeParams{
+		Summary: "s", Detail: "d", Action: "a",
+		Domains: []string{"api"},
+		Pattern: "api-client",
+	})
+	require.NoError(t, err)
+
+	_, err = c.Propose(context.Background(), ProposeParams{
+		Summary: "s2", Detail: "d2", Action: "a2",
+		Domains: []string{"api"},
+	})
+	require.NoError(t, err)
+
+	withPattern, err := c.Query(context.Background(), QueryParams{
+		Domains: []string{"api"},
+		Pattern: "api-client",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, withPattern.Units)
+	require.Equal(t, "s", withPattern.Units[0].Insight.Summary, "the unit with matching pattern should rank first")
+}

--- a/sdk/go/internal/protocol/SKILL.md
+++ b/sdk/go/internal/protocol/SKILL.md
@@ -65,7 +65,7 @@ Do not query cq for:
 
 Choose domain tags that capture the technology, layer, and integration point. Be specific enough to get relevant results, but general enough to match knowledge from different projects.
 
-Both `query` and `propose` use the same plural-array keys for `domains`, `languages`, and `frameworks`. Each is a flat top-level argument; there is no `context` wrapper.
+Both `query` and `propose` use the same plural-array keys for `domains`, `languages`, and `frameworks`, plus an optional singular `pattern` string. Each is a flat top-level argument; there is no `context` wrapper.
 
 | Scenario | `domains` | other call args |
 |----------|-----------|------------------|

--- a/sdk/go/query_options.go
+++ b/sdk/go/query_options.go
@@ -28,6 +28,7 @@ type queryOptions struct {
 	domains    map[string]struct{}
 	languages  map[string]struct{}
 	frameworks map[string]struct{}
+	pattern    string
 	limit      int
 }
 
@@ -125,6 +126,21 @@ func withFramework(framework string) queryOption {
 		}
 
 		p.frameworks[f] = struct{}{}
+
+		return nil
+	}
+}
+
+// withPattern sets the pattern filter on the query. Last call wins; empty input is a no-op.
+func withPattern(pattern string) queryOption {
+	return func(p *queryOptions) error {
+		v := strings.ToLower(strings.TrimSpace(pattern))
+
+		if v == "" {
+			return nil
+		}
+
+		p.pattern = v
 
 		return nil
 	}

--- a/sdk/go/query_options_test.go
+++ b/sdk/go/query_options_test.go
@@ -321,3 +321,31 @@ func TestQueryOptions(t *testing.T) {
 		})
 	}
 }
+
+func TestWithPattern(t *testing.T) {
+	t.Parallel()
+
+	t.Run("lowercases and trims", func(t *testing.T) {
+		t.Parallel()
+
+		opts, err := newQueryOptions(withPattern("  Api-Client  "))
+		require.NoError(t, err)
+		require.Equal(t, "api-client", opts.pattern)
+	})
+
+	t.Run("empty input is a no-op", func(t *testing.T) {
+		t.Parallel()
+
+		opts, err := newQueryOptions(withPattern(""), withPattern("   "))
+		require.NoError(t, err)
+		require.Empty(t, opts.pattern)
+	})
+
+	t.Run("last value wins", func(t *testing.T) {
+		t.Parallel()
+
+		opts, err := newQueryOptions(withPattern("first"), withPattern("second"))
+		require.NoError(t, err)
+		require.Equal(t, "second", opts.pattern)
+	})
+}

--- a/sdk/go/remote.go
+++ b/sdk/go/remote.go
@@ -207,6 +207,10 @@ func (r *remoteClient) query(ctx context.Context, params QueryParams) []Knowledg
 		qv.Add("frameworks", f)
 	}
 
+	if params.Pattern != "" {
+		qv.Set("pattern", params.Pattern)
+	}
+
 	if params.Limit > 0 {
 		qv.Set("limit", fmt.Sprintf("%d", params.Limit))
 	}

--- a/sdk/go/remote_test.go
+++ b/sdk/go/remote_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -261,9 +262,14 @@ func TestRemoteStatsTransportError(t *testing.T) {
 func TestRemoteQueryAddsPatternToURL(t *testing.T) {
 	t.Parallel()
 
-	var capturedURL string
+	var (
+		mu           sync.Mutex
+		capturedURL  string
+	)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		capturedURL = r.URL.String()
+		mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`[]`))
 	}))
@@ -275,15 +281,22 @@ func TestRemoteQueryAddsPatternToURL(t *testing.T) {
 		Pattern: "api-client",
 	})
 
+	mu.Lock()
+	defer mu.Unlock()
 	require.Contains(t, capturedURL, "pattern=api-client")
 }
 
 func TestRemoteQueryOmitsEmptyPattern(t *testing.T) {
 	t.Parallel()
 
-	var capturedURL string
+	var (
+		mu          sync.Mutex
+		capturedURL string
+	)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		capturedURL = r.URL.String()
+		mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`[]`))
 	}))
@@ -292,5 +305,7 @@ func TestRemoteQueryOmitsEmptyPattern(t *testing.T) {
 	rc := newRemoteClient(srv.URL, "test-key", 5*time.Second)
 	rc.query(context.Background(), QueryParams{Domains: []string{"api"}})
 
+	mu.Lock()
+	defer mu.Unlock()
 	require.NotContains(t, capturedURL, "pattern=")
 }

--- a/sdk/go/remote_test.go
+++ b/sdk/go/remote_test.go
@@ -257,3 +257,40 @@ func TestRemoteStatsTransportError(t *testing.T) {
 	_, err := rc.stats(context.Background())
 	require.ErrorIs(t, err, errUnreachable)
 }
+
+func TestRemoteQueryAddsPatternToURL(t *testing.T) {
+	t.Parallel()
+
+	var capturedURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedURL = r.URL.String()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	rc := newRemoteClient(srv.URL, "test-key", 5*time.Second)
+	rc.query(context.Background(), QueryParams{
+		Domains: []string{"api"},
+		Pattern: "api-client",
+	})
+
+	require.Contains(t, capturedURL, "pattern=api-client")
+}
+
+func TestRemoteQueryOmitsEmptyPattern(t *testing.T) {
+	t.Parallel()
+
+	var capturedURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedURL = r.URL.String()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	rc := newRemoteClient(srv.URL, "test-key", 5*time.Second)
+	rc.query(context.Background(), QueryParams{Domains: []string{"api"}})
+
+	require.NotContains(t, capturedURL, "pattern=")
+}

--- a/sdk/go/scoring.go
+++ b/sdk/go/scoring.go
@@ -2,6 +2,7 @@ package cq
 
 import (
 	"slices"
+	"strings"
 	"time"
 )
 
@@ -13,9 +14,10 @@ const (
 	confirmationBoost = 0.1
 	flagPenalty       = 0.15
 
-	domainWeight    = 0.7
+	domainWeight    = 0.55
 	frameworkWeight = 0.15
 	languageWeight  = 0.15
+	patternWeight   = 0.15
 )
 
 // relevance scores how relevant ku is to the given query parameters.
@@ -23,16 +25,20 @@ func (ku KnowledgeUnit) relevance(
 	queryDomains []string,
 	queryLanguages []string,
 	queryFrameworks []string,
+	queryPattern string,
 ) float64 {
 	domainScore := jaccardSimilarity(ku.Domains, queryDomains)
-	var languageScore, frameworkScore float64
+	var languageScore, frameworkScore, patternScore float64
 	if anyMatch(ku.Context.Languages, queryLanguages) {
 		languageScore = 1.0
 	}
 	if anyMatch(ku.Context.Frameworks, queryFrameworks) {
 		frameworkScore = 1.0
 	}
-	score := domainWeight*domainScore + languageWeight*languageScore + frameworkWeight*frameworkScore
+	if queryPattern != "" && ku.Context.Pattern != "" && strings.EqualFold(queryPattern, ku.Context.Pattern) {
+		patternScore = 1.0
+	}
+	score := domainWeight*domainScore + languageWeight*languageScore + frameworkWeight*frameworkScore + patternWeight*patternScore
 	return min(max(score, confidenceFloor), confidenceCeiling)
 }
 

--- a/sdk/go/scoring_test.go
+++ b/sdk/go/scoring_test.go
@@ -153,8 +153,8 @@ func TestKnowledgeUnitRelevance(t *testing.T) {
 		exact := newTestKU(t, []string{"go", "testing"}, 0.5, 1)
 		partial := newTestKU(t, []string{"go", "python"}, 0.5, 1)
 
-		exactScore := exact.relevance([]string{"go", "testing"}, nil, nil)
-		partialScore := partial.relevance([]string{"go", "testing"}, nil, nil)
+		exactScore := exact.relevance([]string{"go", "testing"}, nil, nil, "")
+		partialScore := partial.relevance([]string{"go", "testing"}, nil, nil, "")
 
 		require.Greater(t, exactScore, partialScore)
 	})
@@ -164,7 +164,7 @@ func TestKnowledgeUnitRelevance(t *testing.T) {
 
 		ku := newTestKU(t, []string{"python"}, 0.5, 1)
 		ku.Context = Context{}
-		score := ku.relevance([]string{"rust"}, nil, nil)
+		score := ku.relevance([]string{"rust"}, nil, nil, "")
 
 		require.InDelta(t, 0.0, score, 1e-9)
 	})
@@ -175,8 +175,8 @@ func TestKnowledgeUnitRelevance(t *testing.T) {
 		ku := newTestKU(t, []string{"testing"}, 0.5, 1)
 		ku.Context = Context{Languages: []string{"go"}}
 
-		withLang := ku.relevance([]string{"testing"}, []string{"go"}, nil)
-		withoutLang := ku.relevance([]string{"testing"}, nil, nil)
+		withLang := ku.relevance([]string{"testing"}, []string{"go"}, nil, "")
+		withoutLang := ku.relevance([]string{"testing"}, nil, nil, "")
 
 		require.Greater(t, withLang, withoutLang)
 	})
@@ -187,13 +187,13 @@ func TestKnowledgeUnitRelevance(t *testing.T) {
 		ku := newTestKU(t, []string{"testing"}, 0.5, 1)
 		ku.Context = Context{Frameworks: []string{"grpc"}}
 
-		withFw := ku.relevance([]string{"testing"}, nil, []string{"grpc"})
-		withoutFw := ku.relevance([]string{"testing"}, nil, nil)
+		withFw := ku.relevance([]string{"testing"}, nil, []string{"grpc"}, "")
+		withoutFw := ku.relevance([]string{"testing"}, nil, nil, "")
 
 		require.Greater(t, withFw, withoutFw)
 	})
 
-	t.Run("full match returns 1.0", func(t *testing.T) {
+	t.Run("full match on domain, language, and framework returns 0.85", func(t *testing.T) {
 		t.Parallel()
 
 		ku := newTestKU(t, []string{"go", "testing"}, 0.5, 1)
@@ -202,9 +202,9 @@ func TestKnowledgeUnitRelevance(t *testing.T) {
 			Frameworks: []string{"grpc"},
 		}
 
-		score := ku.relevance([]string{"go", "testing"}, []string{"go"}, []string{"grpc"})
+		score := ku.relevance([]string{"go", "testing"}, []string{"go"}, []string{"grpc"}, "")
 
-		require.InDelta(t, 1.0, score, 1e-9)
+		require.InDelta(t, 0.85, score, 1e-9)
 	})
 
 	t.Run("score is bounded between 0 and 1", func(t *testing.T) {
@@ -228,7 +228,7 @@ func TestKnowledgeUnitRelevance(t *testing.T) {
 		}
 
 		for _, q := range queries {
-			score := ku.relevance(q.domains, q.languages, q.frameworks)
+			score := ku.relevance(q.domains, q.languages, q.frameworks, "")
 			require.True(t, score >= 0.0 && score <= 1.0,
 				"score %f out of bounds for domains=%v languages=%v frameworks=%v",
 				score, q.domains, q.languages, q.frameworks)
@@ -241,8 +241,72 @@ func TestKnowledgeUnitRelevance(t *testing.T) {
 
 		ku := newTestKU(t, []string{}, 0.5, 1)
 		ku.Context = Context{}
-		score := ku.relevance([]string{}, nil, nil)
+		score := ku.relevance([]string{}, nil, nil, "")
 
 		require.InDelta(t, 0.0, score, 1e-9)
 	})
+}
+
+func TestRelevancePatternBoost(t *testing.T) {
+	t.Parallel()
+
+	ku := KnowledgeUnit{
+		Domains: []string{"api"},
+		Context: Context{Pattern: "api-client"},
+	}
+
+	t.Run("matching pattern boosts score", func(t *testing.T) {
+		t.Parallel()
+
+		with := ku.relevance([]string{"api"}, nil, nil, "api-client")
+		without := ku.relevance([]string{"api"}, nil, nil, "")
+
+		require.Greater(t, with, without)
+		require.InDelta(t, without+0.15, with, 1e-9)
+	})
+
+	t.Run("non-matching pattern adds nothing", func(t *testing.T) {
+		t.Parallel()
+
+		with := ku.relevance([]string{"api"}, nil, nil, "cli-tool")
+		without := ku.relevance([]string{"api"}, nil, nil, "")
+
+		require.InDelta(t, without, with, 1e-9)
+	})
+
+	t.Run("pattern match is case-insensitive", func(t *testing.T) {
+		t.Parallel()
+
+		got := ku.relevance([]string{"api"}, nil, nil, "API-Client")
+		expected := ku.relevance([]string{"api"}, nil, nil, "api-client")
+
+		require.InDelta(t, expected, got, 1e-9)
+	})
+
+	t.Run("empty stored pattern never matches", func(t *testing.T) {
+		t.Parallel()
+
+		ku2 := KnowledgeUnit{Domains: []string{"api"}}
+		score := ku2.relevance([]string{"api"}, nil, nil, "any")
+		baseline := ku2.relevance([]string{"api"}, nil, nil, "")
+
+		require.InDelta(t, baseline, score, 1e-9)
+	})
+}
+
+func TestRelevanceWeightsRebalanced(t *testing.T) {
+	t.Parallel()
+
+	ku := KnowledgeUnit{
+		Domains: []string{"api"},
+		Context: Context{Languages: []string{"go"}, Frameworks: []string{"net/http"}, Pattern: "api-client"},
+	}
+
+	score := ku.relevance(
+		[]string{"api"},
+		[]string{"go"},
+		[]string{"net/http"},
+		"api-client",
+	)
+	require.InDelta(t, 1.0, score, 1e-9)
 }

--- a/sdk/go/store.go
+++ b/sdk/go/store.go
@@ -423,7 +423,7 @@ func (s *localStore) query(opt ...queryOption) (storeQueryResult, error) {
 
 	results := make([]ranked, 0, len(candidates))
 	for _, ku := range candidates {
-		relevance := ku.relevance(domains, languages, frameworks)
+		relevance := ku.relevance(domains, languages, frameworks, opts.pattern)
 		confidence := ku.Evidence.Confidence
 		results = append(results, ranked{ku: ku, score: relevance * confidence})
 	}

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -75,6 +75,7 @@ type QueryParams struct {
 	Domains    []string
 	Languages  []string // Optional.
 	Frameworks []string // Optional.
+	Pattern    string   // Optional.
 	Limit      int      // Default 5, max 50.
 }
 

--- a/sdk/python/src/cq/client.py
+++ b/sdk/python/src/cq/client.py
@@ -129,6 +129,7 @@ class Client:
         *,
         languages: list[str] | None = None,
         frameworks: list[str] | None = None,
+        pattern: str = "",
         limit: int = 5,
     ) -> QueryResult:
         """Search for knowledge units by domain tags.
@@ -148,7 +149,13 @@ class Client:
 
         source = "local"
         warnings: list[str] = []
-        local_results = self._store.query(domains, languages=languages, frameworks=frameworks, limit=limit)
+        local_results = self._store.query(
+            domains,
+            languages=languages,
+            frameworks=frameworks,
+            pattern=pattern,
+            limit=limit,
+        )
 
         if self._http is None:
             return QueryResult(units=local_results, source=source)
@@ -159,6 +166,7 @@ class Client:
                 domains,
                 languages=languages,
                 frameworks=frameworks,
+                pattern=pattern,
                 limit=limit,
             )
             source = "remote"
@@ -357,6 +365,7 @@ class Client:
         *,
         languages: list[str] | None = None,
         frameworks: list[str] | None = None,
+        pattern: str = "",
         limit: int = 5,
     ) -> list[KnowledgeUnit]:
         """Query the remote API.
@@ -372,6 +381,8 @@ class Client:
             params["languages"] = languages
         if frameworks:
             params["frameworks"] = frameworks
+        if pattern:
+            params["pattern"] = pattern
         resp = self._http.get("/query", params=params)
         resp.raise_for_status()
         return [KnowledgeUnit.model_validate(item) for item in resp.json()]

--- a/sdk/python/src/cq/protocol/SKILL.md
+++ b/sdk/python/src/cq/protocol/SKILL.md
@@ -65,7 +65,7 @@ Do not query cq for:
 
 Choose domain tags that capture the technology, layer, and integration point. Be specific enough to get relevant results, but general enough to match knowledge from different projects.
 
-Both `query` and `propose` use the same plural-array keys for `domains`, `languages`, and `frameworks`. Each is a flat top-level argument; there is no `context` wrapper.
+Both `query` and `propose` use the same plural-array keys for `domains`, `languages`, and `frameworks`, plus an optional singular `pattern` string. Each is a flat top-level argument; there is no `context` wrapper.
 
 | Scenario | `domains` | other call args |
 |----------|-----------|------------------|

--- a/sdk/python/src/cq/scoring.py
+++ b/sdk/python/src/cq/scoring.py
@@ -13,9 +13,10 @@ _CONFIDENCE_FLOOR = 0.0
 _RELEVANCE_CEILING = 1.0
 _RELEVANCE_FLOOR = 0.0
 
-_DOMAIN_WEIGHT = 0.7
+_DOMAIN_WEIGHT = 0.55
 _LANGUAGE_WEIGHT = 0.15
 _FRAMEWORK_WEIGHT = 0.15
+_PATTERN_WEIGHT = 0.15
 
 
 def apply_confirmation(unit: KnowledgeUnit) -> KnowledgeUnit:
@@ -57,11 +58,12 @@ def calculate_relevance(
     query_domains: list[str],
     query_languages: list[str] | None = None,
     query_frameworks: list[str] | None = None,
+    query_pattern: str = "",
 ) -> float:
     """Score relevance from 0.0 to 1.0 based on domain overlap and context match.
 
-    Domain overlap is the primary signal (weighted at 0.7).
-    Language and framework matches are secondary signals (0.15 each).
+    Domain overlap is the primary signal (weighted at 0.55).
+    Language, framework, and pattern matches are secondary signals (0.15 each).
     """
     query_domains = _as_list(query_domains)
     if query_languages is not None:
@@ -87,5 +89,15 @@ def calculate_relevance(
     if query_frameworks and any(fw in unit.context.frameworks for fw in query_frameworks):
         framework_score = 1.0
 
-    score = _DOMAIN_WEIGHT * domain_score + _LANGUAGE_WEIGHT * language_score + _FRAMEWORK_WEIGHT * framework_score
+    # Pattern match: exact case-insensitive equality between query and unit pattern.
+    pattern_score = (
+        1.0 if query_pattern and unit.context.pattern and query_pattern.lower() == unit.context.pattern.lower() else 0.0
+    )
+
+    score = (
+        _DOMAIN_WEIGHT * domain_score
+        + _LANGUAGE_WEIGHT * language_score
+        + _FRAMEWORK_WEIGHT * framework_score
+        + _PATTERN_WEIGHT * pattern_score
+    )
     return min(max(score, _RELEVANCE_FLOOR), _RELEVANCE_CEILING)

--- a/sdk/python/src/cq/store.py
+++ b/sdk/python/src/cq/store.py
@@ -336,6 +336,7 @@ class LocalStore:
         *,
         languages: list[str] | None = None,
         frameworks: list[str] | None = None,
+        pattern: str = "",
         limit: int = 5,
     ) -> list[KnowledgeUnit]:
         """Search for knowledge units by domain tags with relevance ranking.
@@ -343,7 +344,7 @@ class LocalStore:
         Retrieves units whose domain tags overlap with the query, then
         adds additional candidates from the FTS5 full-text index (these
         may have no domain overlap). All candidates are scored, optionally
-        boosted by language or framework context, and ranked by
+        boosted by language, framework, or pattern context, and ranked by
         relevance * confidence.
 
         Raises:
@@ -418,6 +419,7 @@ class LocalStore:
                 normalized,
                 query_languages=languages,
                 query_frameworks=frameworks,
+                query_pattern=pattern,
             )
             scored.append((relevance * unit.evidence.confidence, unit))
 

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -217,6 +217,25 @@ class TestLocalOnlyMode:
         assert len(result.units) == 2
         assert result.units[0].context.languages == ["python"]
 
+    def test_query_pattern_forwarded_to_store(self, client: Client):
+        """Client.query should pass `pattern` into the local store call so matching units rank first."""
+        client.propose(
+            summary="Pattern match",
+            detail="Detail.",
+            action="Action.",
+            domains=["api"],
+            pattern="api-client",
+        )
+        client.propose(
+            summary="Pattern miss",
+            detail="Detail.",
+            action="Action.",
+            domains=["api"],
+        )
+        result = client.query(["api"], pattern="api-client")
+        assert len(result.units) == 2
+        assert result.units[0].insight.summary == "Pattern match"
+
 
 class TestFullLifecycle:
     def test_propose_confirm_query_flag(self, client: Client):
@@ -346,6 +365,48 @@ class TestRemoteIntegration:
         assert result.source == "remote"
         assert len(result.units) == 1
         assert result.units[0].id == "ku_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa01"
+        c.close()
+
+    def test_remote_query_includes_pattern_param_when_non_empty(self, tmp_path: Path, httpx_mock):
+        """`_remote_query` should include `pattern` in the outgoing HTTP params when non-empty."""
+        remote_unit = {
+            "id": "ku_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa01",
+            "domains": ["api"],
+            "insight": {"summary": "S", "detail": "D", "action": "A"},
+            "tier": "private",
+        }
+        httpx_mock.add_response(
+            url=httpx.URL(
+                "http://test-remote/query",
+                params={"domains": ["api"], "limit": "5", "pattern": "api-client"},
+            ),
+            json=[remote_unit],
+        )
+
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        result = c.query(["api"], pattern="api-client")
+        assert result.source == "remote"
+        assert len(result.units) == 1
+        assert result.units[0].id == "ku_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa01"
+        c.close()
+
+    def test_remote_query_omits_pattern_param_when_empty(self, tmp_path: Path, httpx_mock):
+        """`_remote_query` should omit `pattern` from outgoing params when empty."""
+        remote_unit = {
+            "id": "ku_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa01",
+            "domains": ["api"],
+            "insight": {"summary": "S", "detail": "D", "action": "A"},
+            "tier": "private",
+        }
+        httpx_mock.add_response(
+            url=httpx.URL("http://test-remote/query", params={"domains": ["api"], "limit": "5"}),
+            json=[remote_unit],
+        )
+
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        result = c.query(["api"])
+        assert result.source == "remote"
+        assert len(result.units) == 1
         c.close()
 
     def test_propose_returns_server_response_when_remote_accepts(self, tmp_path: Path, httpx_mock):

--- a/sdk/python/tests/test_scoring.py
+++ b/sdk/python/tests/test_scoring.py
@@ -117,7 +117,7 @@ class TestCalculateRelevance:
         score_without_fw = calculate_relevance(unit, ["databases"], query_frameworks=None)
         assert score_with_fw > score_without_fw
 
-    def test_full_match_returns_one(self):
+    def test_full_match_on_domain_language_framework(self):
         unit = _make_unit(
             domains=["databases"],
             context=Context(languages=["python"], frameworks=["django"]),
@@ -128,7 +128,7 @@ class TestCalculateRelevance:
             query_languages=["python"],
             query_frameworks=["django"],
         )
-        assert score == pytest.approx(1.0)
+        assert score == pytest.approx(0.85)
 
     def test_multi_language_query_boosts_on_any_overlap(self):
         unit = _make_unit(context=Context(languages=["python"], frameworks=[]))
@@ -208,3 +208,53 @@ class TestCalculateRelevance:
         )
         expected = calculate_relevance(unit, ["databases"], query_frameworks=["django"])
         assert score == expected
+
+
+class TestPatternBoost:
+    def test_matching_pattern_boosts_score(self):
+        unit = _make_unit(
+            domains=["api"],
+            context=Context(pattern="api-client"),
+        )
+        with_p = calculate_relevance(unit, ["api"], query_pattern="api-client")
+        without = calculate_relevance(unit, ["api"])
+        assert with_p > without
+        assert abs((without + 0.15) - with_p) < 1e-9
+
+    def test_non_matching_pattern_adds_nothing(self):
+        unit = _make_unit(
+            domains=["api"],
+            context=Context(pattern="api-client"),
+        )
+        with_p = calculate_relevance(unit, ["api"], query_pattern="cli-tool")
+        without = calculate_relevance(unit, ["api"])
+        assert with_p == without
+
+    def test_pattern_match_is_case_insensitive(self):
+        unit = _make_unit(
+            domains=["api"],
+            context=Context(pattern="api-client"),
+        )
+        upper = calculate_relevance(unit, ["api"], query_pattern="API-Client")
+        lower = calculate_relevance(unit, ["api"], query_pattern="api-client")
+        assert upper == lower
+
+    def test_empty_stored_pattern_never_matches(self):
+        unit = _make_unit(domains=["api"])
+        score = calculate_relevance(unit, ["api"], query_pattern="any")
+        baseline = calculate_relevance(unit, ["api"])
+        assert score == baseline
+
+    def test_all_signals_match_reaches_one(self):
+        unit = _make_unit(
+            domains=["api"],
+            context=Context(languages=["python"], frameworks=["fastapi"], pattern="api-client"),
+        )
+        score = calculate_relevance(
+            unit,
+            ["api"],
+            query_languages=["python"],
+            query_frameworks=["fastapi"],
+            query_pattern="api-client",
+        )
+        assert abs(score - 1.0) < 1e-9

--- a/sdk/python/tests/test_store.py
+++ b/sdk/python/tests/test_store.py
@@ -508,6 +508,19 @@ class TestQuery:
         results = store.query(["databases"])
         assert results[0].id == high_conf.id
 
+    def test_pattern_boosts_matching_unit(self, store: LocalStore):
+        """A unit with a matching pattern should rank above an otherwise-equivalent unit."""
+        matching = _make_unit(
+            domains=["api"],
+            context=Context(pattern="api-client"),
+        )
+        plain = _make_unit(domains=["api"])
+        store.insert(matching)
+        store.insert(plain)
+        results = store.query(["api"], pattern="api-client")
+        assert len(results) == 2
+        assert results[0].id == matching.id
+
 
 class TestFTS:
     def test_fts_finds_units_by_summary_text(self, store: LocalStore):

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -93,11 +93,18 @@ def query_units(
     domains: Annotated[list[str], Query()],
     languages: Annotated[list[str] | None, Query()] = None,
     frameworks: Annotated[list[str] | None, Query()] = None,
+    pattern: Annotated[str | None, Query()] = None,
     limit: Annotated[int, Query(gt=0)] = 5,
 ) -> list[KnowledgeUnit]:
     """Search knowledge units by domain tags with relevance ranking."""
     store = _get_store()
-    return store.query(domains, languages=languages, frameworks=frameworks, limit=limit)
+    return store.query(
+        domains,
+        languages=languages,
+        frameworks=frameworks,
+        pattern=pattern or "",
+        limit=limit,
+    )
 
 
 @api_router.post("/propose", status_code=201)

--- a/server/backend/src/cq_server/scoring.py
+++ b/server/backend/src/cq_server/scoring.py
@@ -44,16 +44,19 @@ def calculate_relevance(
     query_domains: list[str],
     query_languages: list[str] | None = None,
     query_frameworks: list[str] | None = None,
+    query_pattern: str = "",
 ) -> float:
     """Score relevance from 0.0 to 1.0 based on domain overlap and context match.
 
-    Domain overlap is the primary signal (weighted at 0.7).
-    Language and framework matches are secondary signals (0.15 each).
+    Domain overlap is the primary signal (weighted at 0.55).
+    Language, framework, and pattern matches are secondary signals (0.15 each).
     A unit scores 1.0 on language or framework if any queried value overlaps.
+    A unit scores 1.0 on pattern if the queried value equals the stored pattern (case-insensitive).
     """
-    domain_weight = 0.7
+    domain_weight = 0.55
     language_weight = 0.15
     framework_weight = 0.15
+    pattern_weight = 0.15
 
     # Domain overlap scored by Jaccard similarity.
     unit_domains = set(unit.domains)
@@ -73,4 +76,14 @@ def calculate_relevance(
     if query_frameworks and set(query_frameworks) & set(unit.context.frameworks):
         framework_score = 1.0
 
-    return domain_weight * domain_score + language_weight * language_score + framework_weight * framework_score
+    # Pattern match: 1.0 on case-insensitive equality when both sides are non-empty.
+    pattern_score = 0.0
+    if query_pattern and unit.context.pattern and query_pattern.lower() == unit.context.pattern.lower():
+        pattern_score = 1.0
+
+    return (
+        domain_weight * domain_score
+        + language_weight * language_score
+        + framework_weight * framework_score
+        + pattern_weight * pattern_score
+    )

--- a/server/backend/src/cq_server/store.py
+++ b/server/backend/src/cq_server/store.py
@@ -260,6 +260,7 @@ class RemoteStore:
         *,
         languages: list[str] | None = None,
         frameworks: list[str] | None = None,
+        pattern: str = "",
         limit: int = 5,
     ) -> list[KnowledgeUnit]:
         """Search for knowledge units by domain tags with relevance ranking.
@@ -270,6 +271,8 @@ class RemoteStore:
                 listed language rank higher but non-matching KUs are still returned.
             frameworks: Optional framework ranking signal. KUs matching any
                 listed framework rank higher but non-matching KUs are still returned.
+            pattern: Optional pattern ranking signal. KUs whose context.pattern
+                matches rank higher but non-matching KUs are still returned.
             limit: Maximum number of results to return. Must be positive.
 
         Returns:
@@ -313,6 +316,7 @@ class RemoteStore:
                 normalized,
                 query_languages=languages,
                 query_frameworks=frameworks,
+                query_pattern=pattern,
             )
             scored.append((relevance * unit.evidence.confidence, unit))
 

--- a/server/backend/tests/test_app.py
+++ b/server/backend/tests/test_app.py
@@ -158,6 +158,23 @@ class TestQuery:
         resp = client.get("/query", params={"domains": ["api"], "limit": 0})
         assert resp.status_code == 422
 
+    def test_query_boosts_matching_pattern(self, client: TestClient) -> None:
+        self._insert_unit(
+            client,
+            domains=["api"],
+            context={"languages": [], "frameworks": [], "pattern": "api-client"},
+        )
+        self._insert_unit(
+            client,
+            domains=["api"],
+            context={"languages": [], "frameworks": [], "pattern": "other-pattern"},
+        )
+        resp = client.get("/query", params={"domains": ["api"], "pattern": "api-client"})
+        assert resp.status_code == 200
+        results = resp.json()
+        assert len(results) == 2
+        assert results[0]["context"]["pattern"] == "api-client"
+
 
 class TestConfirm:
     def test_confirm_boosts_confidence(self, client: TestClient) -> None:

--- a/server/backend/tests/test_scoring.py
+++ b/server/backend/tests/test_scoring.py
@@ -43,3 +43,23 @@ class TestServerPatternBoost:
         upper = calculate_relevance(unit, ["api"], query_pattern="API-Client")
         lower = calculate_relevance(unit, ["api"], query_pattern="api-client")
         assert upper == lower
+
+    def test_empty_stored_pattern_never_matches(self):
+        unit = _make_unit(domains=["api"])
+        score = calculate_relevance(unit, ["api"], query_pattern="any")
+        baseline = calculate_relevance(unit, ["api"])
+        assert score == baseline
+
+    def test_all_signals_match_reaches_one(self):
+        unit = _make_unit(
+            domains=["api"],
+            context=Context(languages=["python"], frameworks=["fastapi"], pattern="api-client"),
+        )
+        score = calculate_relevance(
+            unit,
+            ["api"],
+            query_languages=["python"],
+            query_frameworks=["fastapi"],
+            query_pattern="api-client",
+        )
+        assert abs(score - 1.0) < 1e-9

--- a/server/backend/tests/test_scoring.py
+++ b/server/backend/tests/test_scoring.py
@@ -1,0 +1,45 @@
+"""Tests for confidence scoring and relevance functions."""
+
+from typing import Any
+
+from cq.models import Context, Insight, KnowledgeUnit, create_knowledge_unit
+
+from cq_server.scoring import calculate_relevance
+
+
+def _make_insight(**overrides: Any) -> Insight:
+    defaults = {
+        "summary": "Use connection pooling",
+        "detail": "Database connections are expensive to create.",
+        "action": "Configure a connection pool with a max size of 10.",
+    }
+    return Insight(**{**defaults, **overrides})
+
+
+def _make_unit(**overrides: Any) -> KnowledgeUnit:
+    defaults = {
+        "domains": ["databases", "performance"],
+        "insight": _make_insight(),
+    }
+    return create_knowledge_unit(**{**defaults, **overrides})
+
+
+class TestServerPatternBoost:
+    def test_matching_pattern_boosts(self):
+        unit = _make_unit(domains=["api"], context=Context(pattern="api-client"))
+        with_p = calculate_relevance(unit, ["api"], query_pattern="api-client")
+        without = calculate_relevance(unit, ["api"])
+        assert with_p > without
+        assert abs((without + 0.15) - with_p) < 1e-9
+
+    def test_non_matching_pattern_no_boost(self):
+        unit = _make_unit(domains=["api"], context=Context(pattern="api-client"))
+        with_p = calculate_relevance(unit, ["api"], query_pattern="cli-tool")
+        without = calculate_relevance(unit, ["api"])
+        assert with_p == without
+
+    def test_pattern_case_insensitive(self):
+        unit = _make_unit(domains=["api"], context=Context(pattern="api-client"))
+        upper = calculate_relevance(unit, ["api"], query_pattern="API-Client")
+        lower = calculate_relevance(unit, ["api"], query_pattern="api-client")
+        assert upper == lower

--- a/server/backend/tests/test_store.py
+++ b/server/backend/tests/test_store.py
@@ -197,6 +197,19 @@ class TestQuery:
         assert matched_ids == {fastapi.id, django.id}
         assert results[2].id == flask.id
 
+    def test_pattern_filter_boosts_matching_unit(self, store: RemoteStore) -> None:
+        """KUs whose context.pattern matches the query pattern should rank above those that do not."""
+        matching = _insert_and_approve(
+            store,
+            domains=["api"],
+            context=Context(pattern="api-client"),
+        )
+        plain = _insert_and_approve(store, domains=["api"])
+        results = store.query(["api"], pattern="api-client")
+        assert len(results) == 2
+        assert results[0].id == matching.id
+        assert results[1].id == plain.id
+
     def test_rejects_non_positive_limit(self, store: RemoteStore) -> None:
         with pytest.raises(ValueError, match="limit must be positive"):
             store.query(["databases"], limit=0)


### PR DESCRIPTION
Closes #276.

## Summary

- **`pattern` joins `domains` / `languages` / `frameworks` as a query filter across the cq stack.** Single string (matches the storage shape on `Context.Pattern` and the existing `propose` arg). Soft-boost ranking, not a hard filter — same model as language and framework today.
- **Wired end-to-end:** Go SDK (`QueryParams.Pattern`, `withPattern`, scoring), Python SDK (`Client.query` + `_remote_query` + scoring), server backend (FastAPI `query` endpoint + `Store.query` + scoring), CLI (`--pattern` flag), MCP `query` tool.
- **Scoring rebalanced** so all four signals sum to 1.0: domain 0.55 (was 0.7), language 0.15, framework 0.15, pattern 0.15.
- **Case-insensitive equality** at the comparison point (`EqualFold` in Go, `.lower() == .lower()` in Python). Storage-side normalisation is unchanged (existing convention; out of scope here).
- **SKILL.md schema-note updated** so the doc enumerates all four supported keys.
- **Mutation-verified tests** for the CLI flag, MCP tool, and full e2e MCP path — each fails deterministically if the pattern wiring is removed.

## Behavioural impact

Existing queries that don't pass `pattern` produce slightly lower absolute relevance numbers than before because the domain weight shrank from 0.7 to 0.55. Relative ranking within a result set is unchanged. Cross-query absolute comparability is tracked separately in #279 (dynamic per-query weight renormalisation).

## Required fast-follow work

This PR re-enables the monorepo `replace` directive in `cli/go.mod` so the CLI compiles against the new `QueryParams.Pattern` field (SDK v0.2.2 predates it). Two fast-follow steps after merge:

1. **Tag `sdk/go` v0.3.0** from the merge commit on main. The scoring rebalance is a behavioural change beyond a field-additive bump.
2. **Bump `cli/go.mod`** to v0.3.0 and re-comment the `replace` directive — staged as draft PR #281, ready to rebase + `go mod tidy` once the tag exists.

## Test plan

- [x] `make lint`
- [x] `make test`
- [x] New regression tests in every layer:
  - Go SDK `scoring_test.go`, `query_options_test.go`, `client_test.go`, `remote_test.go`.
  - Python SDK `test_scoring.py`, `test_store.py`, `test_client.py`.
  - Server backend `test_scoring.py`, `test_store.py`, `test_app.py`.
  - CLI `cmd/query_test.go` (mutation-verified), `mcpserver/query_test.go`, `mcpserver/e2e_test.go` (mutation-verified).

## Out of scope

- Hard-filter semantics for `pattern`.
- Storage-side normalisation of pattern/language/framework.
- Dynamic per-query weight renormalisation (#279).
- The version bumps described above.