### PR TITLE
Bump CLI sdk/go pin to v0.3.0 and re-disable monorepo replace

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/mark3labs/mcp-go v0.46.0
-	github.com/mozilla-ai/cq/sdk/go v0.2.2
+	github.com/mozilla-ai/cq/sdk/go v0.3.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9
 	github.com/stretchr/testify v1.11.1
@@ -31,4 +31,4 @@ require (
 )
 
 // Monorepo: uncomment to use the local SDK during development.
-replace github.com/mozilla-ai/cq/sdk/go => ../sdk/go
+// replace github.com/mozilla-ai/cq/sdk/go => ../sdk/go

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -25,8 +25,8 @@ github.com/mark3labs/mcp-go v0.46.0 h1:8KRibF4wcKejbLsHxCA/QBVUr5fQ9nwz/n8lGqmaA
 github.com/mark3labs/mcp-go v0.46.0/go.mod h1:JKTC7R2LLVagkEWK7Kwu7DbmA6iIvnNAod6yrHiQMag=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/mozilla-ai/cq/sdk/go v0.2.2 h1:bGDdwxcniwfmkQqP+WyBvHY2W1tFjldaMVsI/bDeD+g=
-github.com/mozilla-ai/cq/sdk/go v0.2.2/go.mod h1:gqXCbhabJXzN+UT8kfmhUcLYrfcaWDP45XgmQf4baN0=
+github.com/mozilla-ai/cq/sdk/go v0.3.0 h1:p465l6jOb0w0uKsQunmNolS/hZ46SRUfVSmzY/NYGzI=
+github.com/mozilla-ai/cq/sdk/go v0.3.0/go.mod h1:gqXCbhabJXzN+UT8kfmhUcLYrfcaWDP45XgmQf4baN0=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Follow-up to #280.

## Why this PR

#280 adds `pattern` to `QueryParams` (among other things), but the released `sdk/go v0.2.2` predates that field. To make the in-monorepo build work, #280 temporarily uncommented the replace directive in `cli/go.mod`:

```
replace github.com/mozilla-ai/cq/sdk/go => ../sdk/go
```

A relative-path `replace` doesn't ship in the Go module proxy zip, so external consumers of `github.com/mozilla-ai/cq/cli` would fail to build any commit that has the directive active. 

This PR closes that window:

- Bumps `cli/go.mod` `require github.com/mozilla-ai/cq/sdk/go` from `v0.2.2` to `v0.3.0`.
- Re-comments the `replace` directive so it returns to its dev-only role.
- Updates `cli/go.sum` for the new module hash.

## Status

- [x] #280 merged.
- [x] `sdk/go/v0.3.0` tagged.
- [x] Branch rebased onto new main.
- [x] `go mod tidy` populated `go.sum` for v0.3.0.
- [x] Local `go build ./...` and `go test ./...` from `cli/` pass against v0.3.0.

Ready for CI + review.

## Out of scope

The actual SDK source changes — those live in #280.