### PR TITLE
Bump plugin to 0.7.3 and cli_min_version to 0.3.0

### DIFF
--- a/plugins/cq/.claude-plugin/plugin.json
+++ b/plugins/cq/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cq",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Shared knowledge commons for AI agents; find, share, and confirm collective knowledge to stop rediscovering the same failures.",
   "author": {
     "name": "Mozilla AI",

--- a/plugins/cq/pyproject.toml
+++ b/plugins/cq/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cq-plugin"
-version = "0.7.2"
+version = "0.7.3"
 description = "cq Plugin for coding agents (e.g. Claude Code, OpenCode) - shared agent knowledge commons"
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }

--- a/plugins/cq/scripts/bootstrap.json
+++ b/plugins/cq/scripts/bootstrap.json
@@ -1,3 +1,3 @@
 {
-  "cli_min_version": "0.2.2"
+  "cli_min_version": "0.3.0"
 }

--- a/plugins/cq/uv.lock
+++ b/plugins/cq/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "cq-plugin"
-version = "0.7.2"
+version = "0.7.3"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Follow-up to #280.

## Why this PR

#280 added `pattern` to the MCP `query` tool, which only exists in CLI v0.3.0+. This PR bumps the plugin's minimum-required CLI version so users who update the plugin get prompted to update their CLI binary, and bumps the plugin version itself so update notifications actually propagate.

## Changes

- `plugins/cq/scripts/bootstrap.json` — `cli_min_version` 0.2.2 → 0.3.0.
- `plugins/cq/.claude-plugin/plugin.json` — plugin `version` 0.7.2 → 0.7.3.
- `plugins/cq/pyproject.toml` — same 0.7.2 → 0.7.3 (kept in sync with plugin.json).
- `plugins/cq/uv.lock` — regenerated via `make setup-plugin` to pick up the version bump.

Follows the precedent of #267 which bundled plugin + cli_min_version bumps together.

[`cli/v0.3.0`](https://github.com/mozilla-ai/cq/releases/tag/cli%2Fv0.3.0) is already released so the min-version requirement is satisfiable immediately.

## Test plan

- [x] `make test` passes.
- [x] `make lint` passes.