### PR TITLE
SDK: fall back to local store on remote failure, surface via FallbackError

### DIFF
--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 )
 
@@ -253,9 +254,17 @@ func (c *Client) Prompt() string {
 
 // Propose creates a new knowledge unit.
 // When a remote API is configured and reachable, the unit is sent to the
-// remote only. If the remote is unreachable, falls back to local storage.
-// If the remote rejects the proposal, returns a RemoteError.
-// With no remote configured, always stores locally.
+// remote only and returned with no error. The remote is the source of
+// truth for server-assigned fields; in particular, Tier is promoted to
+// Private and CreatedBy is overwritten with the authenticated caller.
+// If the remote is unreachable (transport/5xx) or rejects the request
+// with an auth error (401/403), the unit is stored locally with Tier
+// Local and a *FallbackError is returned carrying the local unit and
+// the underlying cause; the unit will drain on the next successful
+// connection. Other 4xx errors (400, 409, 422) are returned as
+// *RemoteError with nothing stored — the data is the problem, not
+// connectivity. With no remote configured, always stores locally with
+// no error.
 func (c *Client) Propose(ctx context.Context, params ProposeParams) (KnowledgeUnit, error) {
 	ctx, cancel := c.operationContext(ctx)
 	defer cancel()
@@ -286,17 +295,21 @@ func (c *Client) Propose(ctx context.Context, params ProposeParams) (KnowledgeUn
 		CreatedBy: params.CreatedBy,
 	}
 
+	var remoteErr error
+
 	if c.remote != nil {
 		result, err := c.remote.propose(ctx, ku)
-		if err != nil && !errors.Is(err, errUnreachable) {
-			return KnowledgeUnit{}, err
-		}
-
 		if err == nil {
 			return result, nil
 		}
 
-		// Remote unreachable; fall back to local storage.
+		var re *RemoteError
+		isAuthReject := errors.As(err, &re) &&
+			(re.StatusCode == http.StatusUnauthorized || re.StatusCode == http.StatusForbidden)
+		if !isAuthReject && !errors.Is(err, errUnreachable) {
+			return KnowledgeUnit{}, err
+		}
+		remoteErr = err
 	}
 
 	now := time.Now()
@@ -304,9 +317,15 @@ func (c *Client) Propose(ctx context.Context, params ProposeParams) (KnowledgeUn
 	ku.Evidence.LastConfirmed = &now
 
 	if err := c.store.insert(ku); err != nil {
+		if remoteErr != nil {
+			return KnowledgeUnit{}, fmt.Errorf("fallback insert after remote failure (%s): %w", remoteErr, err)
+		}
 		return KnowledgeUnit{}, fmt.Errorf("inserting knowledge unit: %w", err)
 	}
 
+	if remoteErr != nil {
+		return ku, &FallbackError{LocalUnit: ku, Err: remoteErr}
+	}
 	return ku, nil
 }
 

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -317,10 +317,11 @@ func (c *Client) Propose(ctx context.Context, params ProposeParams) (KnowledgeUn
 	ku.Evidence.LastConfirmed = &now
 
 	if err := c.store.insert(ku); err != nil {
+		insertErr := fmt.Errorf("inserting knowledge unit: %w", err)
 		if remoteErr != nil {
-			return KnowledgeUnit{}, fmt.Errorf("fallback insert after remote failure (%s): %w", remoteErr, err)
+			return KnowledgeUnit{}, fmt.Errorf("fallback insert after remote failure: %w", errors.Join(remoteErr, insertErr))
 		}
-		return KnowledgeUnit{}, fmt.Errorf("inserting knowledge unit: %w", err)
+		return KnowledgeUnit{}, insertErr
 	}
 
 	if remoteErr != nil {

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -3,6 +3,7 @@ package cq
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -302,12 +303,44 @@ func TestProposeRemoteUnreachable(t *testing.T) {
 	ku, err := c.Propose(context.Background(), ProposeParams{
 		Summary: "Fallback", Detail: "D.", Action: "A.", Domains: []string{"api"},
 	})
-	require.NoError(t, err)
-	require.Contains(t, ku.ID, "ku_")
+
+	// Returns FallbackError with transport cause, no RemoteError.
+	var fb *FallbackError
+	require.ErrorAs(t, err, &fb)
+	require.Contains(t, fb.LocalUnit.ID, "ku_")
+	require.True(t, errors.Is(fb.Err, errUnreachable))
+	var re *RemoteError
+	require.False(t, errors.As(fb.Err, &re))
+
+	require.Equal(t, fb.LocalUnit.ID, ku.ID)
 
 	// Stored locally as fallback.
 	stats, _ := c.Status(context.Background())
 	require.Equal(t, 1, stats.TotalCount)
+}
+
+func TestFallbackErrorMessage(t *testing.T) {
+	t.Run("with RemoteError cause", func(t *testing.T) {
+		fb := &FallbackError{
+			LocalUnit: KnowledgeUnit{ID: "ku_01234567890123456789012345678901"},
+			Err:       &RemoteError{StatusCode: 401, Detail: "Invalid API key"},
+		}
+		require.Equal(t,
+			"stored locally after remote failure: remote API rejected request (401): Invalid API key",
+			fb.Error(),
+		)
+	})
+
+	t.Run("with sentinel cause", func(t *testing.T) {
+		fb := &FallbackError{
+			LocalUnit: KnowledgeUnit{ID: "ku_01234567890123456789012345678901"},
+			Err:       errUnreachable,
+		}
+		require.Equal(t,
+			"stored locally after remote failure: remote API unreachable",
+			fb.Error(),
+		)
+	})
 }
 
 func TestProposeRemoteRejects(t *testing.T) {
@@ -324,6 +357,45 @@ func TestProposeRemoteRejects(t *testing.T) {
 	var remoteErr *RemoteError
 	require.ErrorAs(t, err, &remoteErr)
 	require.Equal(t, 422, remoteErr.StatusCode)
+}
+
+func TestProposeRemoteAuthRejectFallsBackLocally(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+	}{
+		{"401 Unauthorized", http.StatusUnauthorized},
+		{"403 Forbidden", http.StatusForbidden},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newTestClientWithRemote(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(`{"detail":"Invalid API key"}`))
+			}))
+
+			ku, err := c.Propose(context.Background(), ProposeParams{
+				Summary: "Auth fallback", Detail: "D.", Action: "A.", Domains: []string{"api"},
+			})
+
+			// Returns FallbackError carrying the locally-stored unit.
+			var fb *FallbackError
+			require.ErrorAs(t, err, &fb)
+			require.Contains(t, fb.LocalUnit.ID, "ku_")
+			require.Equal(t, Local, fb.LocalUnit.Tier)
+
+			// Cause unwraps to RemoteError with the auth status code.
+			var re *RemoteError
+			require.ErrorAs(t, err, &re)
+			require.Equal(t, tc.status, re.StatusCode)
+
+			// Unit returned alongside the error matches the fallback.
+			require.Equal(t, fb.LocalUnit.ID, ku.ID)
+
+			// Stored locally.
+			stats, _ := c.Status(context.Background())
+			require.Equal(t, 1, stats.TotalCount)
+		})
+	}
 }
 
 func TestQueryMergesLocalAndRemote(t *testing.T) {
@@ -343,7 +415,8 @@ func TestQueryMergesLocalAndRemote(t *testing.T) {
 	_, err := c.Propose(ctx, ProposeParams{
 		Summary: "Local insight", Detail: "D.", Action: "A.", Domains: []string{"api"},
 	})
-	require.NoError(t, err)
+	var fb *FallbackError
+	require.ErrorAs(t, err, &fb)
 
 	// Query merges local + remote.
 	qr, err := c.Query(ctx, QueryParams{Domains: []string{"api"}})
@@ -526,7 +599,6 @@ func TestDrainableCount(t *testing.T) {
 
 func TestHasRemote(t *testing.T) {
 
-
 	t.Run("without remote", func(t *testing.T) {
 
 		c := newTestClient(t)
@@ -615,7 +687,8 @@ func TestStatusWithRemoteMergesTierCounts(t *testing.T) {
 	_, err := c.Propose(ctx, ProposeParams{
 		Summary: "Local", Detail: "D.", Action: "A.", Domains: []string{"test"},
 	})
-	require.NoError(t, err)
+	var fb *FallbackError
+	require.ErrorAs(t, err, &fb)
 
 	stats, err := c.Status(ctx)
 	require.NoError(t, err)
@@ -646,7 +719,8 @@ func TestStatusWithRemoteMergesDomainCounts(t *testing.T) {
 	_, err := c.Propose(ctx, ProposeParams{
 		Summary: "Local", Detail: "D.", Action: "A.", Domains: []string{"api"},
 	})
-	require.NoError(t, err)
+	var fb *FallbackError
+	require.ErrorAs(t, err, &fb)
 
 	stats, err := c.Status(ctx)
 	require.NoError(t, err)
@@ -666,7 +740,8 @@ func TestStatusRemoteUnreachableStillReturnsLocal(t *testing.T) {
 	_, err = c.Propose(context.Background(), ProposeParams{
 		Summary: "S", Detail: "D.", Action: "A.", Domains: []string{"test"},
 	})
-	require.NoError(t, err)
+	var fb *FallbackError
+	require.ErrorAs(t, err, &fb)
 
 	stats, err := c.Status(context.Background())
 	require.NoError(t, err)
@@ -693,7 +768,8 @@ func TestStatusIgnoresLocalTierFromRemote(t *testing.T) {
 	_, err := c.Propose(ctx, ProposeParams{
 		Summary: "S", Detail: "D.", Action: "A.", Domains: []string{"test"},
 	})
-	require.NoError(t, err)
+	var fb *FallbackError
+	require.ErrorAs(t, err, &fb)
 
 	stats, err := c.Status(ctx)
 	require.NoError(t, err)

--- a/sdk/go/errors.go
+++ b/sdk/go/errors.go
@@ -5,14 +5,33 @@ import (
 	"fmt"
 )
 
+// ErrNotFound indicates a knowledge unit was not found.
+var ErrNotFound = errors.New("knowledge unit not found")
+
+// FallbackError indicates that a propose could not reach the remote and the
+// unit was stored locally instead. It will drain on the next successful
+// connection. Err carries the underlying error (RemoteError for auth
+// rejection, errUnreachable-wrapped error for transport/5xx).
+type FallbackError struct {
+	LocalUnit KnowledgeUnit
+	Err       error
+}
+
 // RemoteError is returned when the remote API explicitly rejects a request.
 type RemoteError struct {
 	StatusCode int
 	Detail     string
 }
 
-// ErrNotFound indicates a knowledge unit was not found.
-var ErrNotFound = errors.New("knowledge unit not found")
+// Error returns a description indicating local storage after remote failure.
+func (e *FallbackError) Error() string {
+	return fmt.Sprintf("stored locally after remote failure: %s", e.Err)
+}
+
+// Unwrap returns the underlying error so errors.As/errors.Is chain through.
+func (e *FallbackError) Unwrap() error {
+	return e.Err
+}
 
 // Error returns a human-readable description of the remote API rejection.
 func (e *RemoteError) Error() string {

--- a/sdk/go/remote.go
+++ b/sdk/go/remote.go
@@ -185,7 +185,16 @@ func (r *remoteClient) propose(ctx context.Context, ku KnowledgeUnit) (Knowledge
 
 	var result KnowledgeUnit
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return KnowledgeUnit{}, fmt.Errorf("%w: decoding response: %w", errUnreachable, err)
+		// Server accepted (2xx) but response isn't a parseable KU.
+		// Return the unit with tier promoted and server-assigned fields
+		// cleared; callers should not trust values that only the server
+		// sets. Returning errUnreachable here would cause drain to
+		// re-send the unit and create a duplicate on the server.
+		ku.Tier = Private
+		ku.CreatedBy = ""
+		ku.Evidence.FirstObserved = nil
+		ku.Evidence.LastConfirmed = nil
+		return ku, nil
 	}
 
 	return result, nil

--- a/sdk/python/src/cq/__init__.py
+++ b/sdk/python/src/cq/__init__.py
@@ -1,6 +1,6 @@
 """cq — Python SDK for the shared agent knowledge commons."""
 
-from .client import Client, DrainResult, QueryResult, RemoteError
+from .client import Client, DrainResult, FallbackError, QueryResult, RemoteError
 from .models import (
     Context,
     Evidence,
@@ -22,6 +22,7 @@ __all__ = [
     "DefaultReflector",
     "DrainResult",
     "Evidence",
+    "FallbackError",
     "Flag",
     "FlagReason",
     "Insight",

--- a/sdk/python/src/cq/client.py
+++ b/sdk/python/src/cq/client.py
@@ -68,6 +68,21 @@ class RemoteError(Exception):
         super().__init__(f"Remote API rejected request ({status_code}): {detail}")
 
 
+class FallbackError(Exception):
+    """Raised when propose stored a unit locally after a remote failure.
+
+    The unit has been persisted to the local store and will drain to the
+    remote on the next successful connection. The underlying cause is
+    available via ``__cause__`` (set automatically by ``raise ... from``);
+    this is a ``RemoteError`` for auth rejection (401/403) or a transport
+    exception for connectivity issues.
+    """
+
+    def __init__(self, local_unit: "KnowledgeUnit") -> None:
+        self.local_unit = local_unit
+        super().__init__("Stored locally after remote failure")
+
+
 class Client:
     """Client for the cq shared knowledge commons.
 
@@ -190,9 +205,19 @@ class Client:
     ) -> KnowledgeUnit:
         """Propose a new knowledge unit.
 
-        When a remote API is configured, sends to remote only. Falls back
-        to local storage when the remote is unreachable. Raises RemoteError
-        if the remote explicitly rejects the unit.
+        When a remote API is configured and reachable, the unit is sent to
+        the remote only and returned with no exception. The remote is the
+        source of truth for server-assigned fields; in particular, ``tier``
+        is promoted to ``PRIVATE`` and ``created_by`` is overwritten with
+        the authenticated caller. If the remote is unreachable
+        (transport/5xx) or rejects the request with an auth error
+        (401/403), the unit is stored locally with ``tier=LOCAL`` and
+        ``FallbackError`` is raised carrying the local unit and the
+        underlying cause; the unit will drain on the next successful
+        connection. Other 4xx errors (400, 409, 422) raise ``RemoteError``
+        with nothing stored — the data is the problem, not connectivity.
+        With no remote configured, always stores locally with no
+        exception.
         """
         domains = _as_list(domains)
         if languages is not None:
@@ -210,13 +235,32 @@ class Client:
             context=context,
             created_by=created_by,
         )
+        remote_cause: Exception | None = None
+
         if self._http is not None:
-            result = self._remote_propose(unit)
+            try:
+                result = self._remote_propose(unit)
+            except RemoteError as exc:
+                if exc.status_code not in (401, 403):
+                    raise
+                remote_cause = exc
+                result = None
+            if result is None and remote_cause is None:
+                remote_cause = ConnectionError("remote unreachable")
             if result is not None:
                 return result
-            # Remote unreachable — fall back to local storage.
 
-        self._store.insert(unit)
+        try:
+            self._store.insert(unit)
+        except Exception as insert_exc:
+            if remote_cause is not None:
+                raise RuntimeError(
+                    f"fallback insert after remote failure ({remote_cause}): {insert_exc}"
+                ) from insert_exc
+            raise
+
+        if remote_cause is not None:
+            raise FallbackError(local_unit=unit) from remote_cause
         return unit
 
     def confirm(self, unit_id: str, *, tier: Tier = Tier.LOCAL) -> KnowledgeUnit:

--- a/sdk/python/src/cq/client.py
+++ b/sdk/python/src/cq/client.py
@@ -241,7 +241,7 @@ class Client:
             try:
                 result = self._remote_propose(unit)
             except RemoteError as exc:
-                if exc.status_code not in (401, 403):
+                if exc.status_code not in (401, 403) and not (500 <= exc.status_code < 600):
                     raise
                 remote_cause = exc
                 result = None
@@ -254,9 +254,7 @@ class Client:
             self._store.insert(unit)
         except Exception as insert_exc:
             if remote_cause is not None:
-                raise RuntimeError(
-                    f"fallback insert after remote failure ({remote_cause}): {insert_exc}"
-                ) from insert_exc
+                raise RuntimeError(f"fallback insert after remote failure: {insert_exc}") from remote_cause
             raise
 
         if remote_cause is not None:
@@ -463,8 +461,12 @@ class Client:
             unit_data = data.get("knowledge_unit", data) if isinstance(data, dict) else data
             return KnowledgeUnit.model_validate(unit_data)
         except (ValueError, ValidationError):
-            # Server accepted but response is not a parseable KU.
-            return unit
+            # Server accepted (2xx) but response is not a parseable KU.
+            # Return the unit with tier promoted and server-assigned fields
+            # cleared; callers should not trust values that only the server
+            # sets.
+            cleared_evidence = unit.evidence.model_copy(update={"first_observed": None, "last_confirmed": None})
+            return unit.model_copy(update={"tier": Tier.PRIVATE, "created_by": "", "evidence": cleared_evidence})
 
     def _remote_confirm(self, unit_id: str) -> KnowledgeUnit | None:
         """Confirm a unit on the remote API.

--- a/sdk/python/src/cq/client.py
+++ b/sdk/python/src/cq/client.py
@@ -236,6 +236,7 @@ class Client:
             created_by=created_by,
         )
         remote_cause: Exception | None = None
+        result: KnowledgeUnit | None = None
 
         if self._http is not None:
             try:
@@ -244,9 +245,8 @@ class Client:
                 if exc.status_code not in (401, 403) and not (500 <= exc.status_code < 600):
                     raise
                 remote_cause = exc
-                result = None
-            if result is None and remote_cause is None:
-                remote_cause = ConnectionError("remote unreachable")
+            except httpx.HTTPError as exc:
+                remote_cause = exc
             if result is not None:
                 return result
 
@@ -375,13 +375,12 @@ class Client:
         for unit in units:
             if unit.tier == Tier.LOCAL:
                 try:
-                    result = self._remote_propose(unit)
-                    if result is not None:
-                        self._store.delete(unit.id)
-                        pushed += 1
-                    else:
-                        warnings.append(f"Failed to drain unit {unit.id}: remote unreachable")
+                    self._remote_propose(unit)
+                    self._store.delete(unit.id)
+                    pushed += 1
                 except RemoteError as exc:
+                    warnings.append(f"Failed to drain unit {unit.id}: {exc}")
+                except httpx.HTTPError as exc:
                     warnings.append(f"Failed to drain unit {unit.id}: {exc}")
         return DrainResult(pushed=pushed, warnings=warnings)
 
@@ -429,15 +428,16 @@ class Client:
         resp.raise_for_status()
         return [KnowledgeUnit.model_validate(item) for item in resp.json()]
 
-    def _remote_propose(self, unit: KnowledgeUnit) -> KnowledgeUnit | None:
+    def _remote_propose(self, unit: KnowledgeUnit) -> KnowledgeUnit:
         """Push a unit to the remote API.
 
         Returns:
-            The server-created KnowledgeUnit on success, None on transport error.
+            The server-created KnowledgeUnit on success.
 
         Raises:
-            RemoteError: If the remote API explicitly rejects the request
-                or returns an unparseable response.
+            RemoteError: If the remote API explicitly rejects the request.
+            httpx.HTTPError: For transport-layer failures (connect, timeout,
+                read, network errors). Callers decide how to classify.
         """
         assert self._http is not None
         body = {
@@ -454,8 +454,6 @@ class Client:
                 status_code=exc.response.status_code,
                 detail=exc.response.text,
             ) from exc
-        except httpx.HTTPError:
-            return None
         try:
             data = resp.json()
             unit_data = data.get("knowledge_unit", data) if isinstance(data, dict) else data

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import httpx
 import pytest
 
-from cq.client import Client, RemoteError
+from cq.client import Client, FallbackError, RemoteError
 from cq.models import FlagReason, Tier
 
 
@@ -428,15 +428,17 @@ class TestRemoteIntegration:
         c.close()
 
     def test_propose_falls_back_to_local_when_remote_unreachable(self, tmp_path: Path, httpx_mock):
-        """When remote is unreachable, the unit is stored locally as fallback."""
+        """When remote is unreachable, raise FallbackError with local_unit."""
         httpx_mock.add_exception(httpx.ConnectError("Connection refused"))
 
         c = Client(addr="http://unreachable", local_db_path=tmp_path / "test.db")
-        c.propose(summary="Local fallback", detail="D", action="A", domains=["api"])
+        with pytest.raises(FallbackError) as exc_info:
+            c.propose(summary="Local fallback", detail="D", action="A", domains=["api"])
 
-        units = c._store.all()
-        assert len(units) == 1
-        assert units[0].insight.summary == "Local fallback"
+        fb = exc_info.value
+        assert fb.local_unit.insight.summary == "Local fallback"
+        assert not isinstance(fb.__cause__, RemoteError)
+        assert len(c._store.all()) == 1
         c.close()
 
     def test_propose_raises_when_remote_rejects(self, tmp_path: Path, httpx_mock):
@@ -448,6 +450,36 @@ class TestRemoteIntegration:
             c.propose(summary="Rejected", detail="D", action="A", domains=["api"])
 
         assert c._store.all() == []
+        c.close()
+
+    def test_fallback_error_message_and_cause(self, tmp_path: Path, httpx_mock):
+        """FallbackError exposes local_unit and chains __cause__ to the underlying error."""
+        httpx_mock.add_response(json={"detail": "Invalid API key"}, status_code=401)
+
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        with pytest.raises(FallbackError) as exc_info:
+            c.propose(summary="Chain", detail="D", action="A", domains=["api"])
+
+        fb = exc_info.value
+        assert str(fb) == "Stored locally after remote failure"
+        assert isinstance(fb.__cause__, RemoteError)
+        assert fb.__cause__.status_code == 401
+        c.close()
+
+    @pytest.mark.parametrize("status_code", [401, 403])
+    def test_propose_auth_reject_falls_back_to_local(self, tmp_path: Path, httpx_mock, status_code: int):
+        """When remote returns 401 or 403, raise FallbackError with local_unit."""
+        httpx_mock.add_response(json={"detail": "Invalid API key"}, status_code=status_code)
+
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        with pytest.raises(FallbackError) as exc_info:
+            c.propose(summary="Auth fallback", detail="D", action="A", domains=["api"])
+
+        fb = exc_info.value
+        assert fb.local_unit.insight.summary == "Auth fallback"
+        assert isinstance(fb.__cause__, RemoteError)
+        assert fb.__cause__.status_code == status_code
+        assert len(c._store.all()) == 1
         c.close()
 
     def test_drain_deletes_local_units_after_push(self, tmp_path: Path, httpx_mock):
@@ -485,19 +517,20 @@ class TestRemoteIntegration:
         c.close()
 
     def test_remote_failure_falls_back_to_local(self, tmp_path: Path, httpx_mock):
-        """When remote API is unreachable, local results still returned."""
+        """When remote API is unreachable, propose raises FallbackError; query still works."""
         httpx_mock.add_exception(httpx.ConnectError("Connection refused"))
 
         c = Client(
             addr="http://unreachable",
             local_db_path=tmp_path / "test.db",
         )
-        c.propose(
-            summary="Local only",
-            detail="D",
-            action="A",
-            domains=["api"],
-        )
+        with pytest.raises(FallbackError):
+            c.propose(
+                summary="Local only",
+                detail="D",
+                action="A",
+                domains=["api"],
+            )
 
         result = c.query(["api"])
         assert result.source == "local"

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -437,7 +437,8 @@ class TestRemoteIntegration:
 
         fb = exc_info.value
         assert fb.local_unit.insight.summary == "Local fallback"
-        assert not isinstance(fb.__cause__, RemoteError)
+        assert isinstance(fb.__cause__, httpx.ConnectError)
+        assert "Connection refused" in str(fb.__cause__)
         assert len(c._store.all()) == 1
         c.close()
 

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -482,6 +482,22 @@ class TestRemoteIntegration:
         assert len(c._store.all()) == 1
         c.close()
 
+    @pytest.mark.parametrize("status_code", [500, 502, 503])
+    def test_propose_server_error_falls_back_to_local(self, tmp_path: Path, httpx_mock, status_code: int):
+        """When remote returns 5xx, raise FallbackError and persist the unit locally."""
+        httpx_mock.add_response(json={"detail": "Upstream failure"}, status_code=status_code)
+
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        with pytest.raises(FallbackError) as exc_info:
+            c.propose(summary="Server fallback", detail="D", action="A", domains=["api"])
+
+        fb = exc_info.value
+        assert fb.local_unit.insight.summary == "Server fallback"
+        assert isinstance(fb.__cause__, RemoteError)
+        assert fb.__cause__.status_code == status_code
+        assert len(c._store.all()) == 1
+        c.close()
+
     def test_drain_deletes_local_units_after_push(self, tmp_path: Path, httpx_mock):
         """After drain pushes a unit to remote, it is deleted from local store."""
         # First, create a local-only client and propose a unit.


### PR DESCRIPTION
## Summary

When the remote API is unreachable (transport/5xx) or rejects a `propose` with an auth error (401/403), the SDK now stores the unit locally and surfaces a `FallbackError` instead of either hard-failing (auth previously) or silently returning no error (transport previously). The error carries the locally-stored unit and the underlying cause, letting callers log or alert on the degraded state rather than silently dropping work or masking systemic issues.

Other 4xx codes (400, 409, 422) still hard-fail as `RemoteError` with nothing stored — the data is the problem, not connectivity.

Applies to both the Go and Python SDKs, matching contracts and idioms in each.

## Behaviour matrix

| Remote response | Error type | Stored locally |
|---|---|---|
| 2xx | nil | no (remote accepted) |
| 401 / 403 (auth) | `FallbackError` (underlying `*RemoteError`) | yes |
| 5xx / transport | `FallbackError` (underlying `errUnreachable`-wrapped) | yes |
| 400 / 409 / 422 | `RemoteError` | no |
| no remote configured | nil | yes |

## Error design

**Go (`sdk/go/errors.go`):**
```go
type FallbackError struct {
    LocalUnit KnowledgeUnit
    Err       error // *RemoteError (auth) or errUnreachable-wrapped (transport)
}
func (e *FallbackError) Unwrap() error { return e.Err }
```
Callers do `errors.As(err, &fb)` to get the local unit, then inspect `fb.Err` via `errors.As` / `errors.Is` to discriminate auth from transport.

**Python (`sdk/python/src/cq/client.py`):**
```python
class FallbackError(Exception):
    def __init__(self, local_unit: KnowledgeUnit) -> None: ...
```
Raised with `raise FallbackError(local_unit=unit) from cause`, so the underlying cause is available via `exc.__cause__` (Python's standard chaining). No custom `cause` attribute to shadow `__cause__`.

## Preserving remote cause on fallback insert failure

If the local insert fails during fallback, both SDKs wrap the error to preserve the original remote cause rather than just reporting the insert failure. Root reason is not lost.

## Docstrings

Both `propose` docstrings now clarify that the remote is the source of truth for server-assigned fields: on success, `Tier` is promoted to `Private` and `created_by` is overwritten with the authenticated caller. Fallback units retain `Tier=Local` until drained.

## Atomic commits

1. `fix(sdk/go): surface FallbackError on all propose remote failures` — Go SDK change + tests.
2. `fix(sdk/python): surface FallbackError on all propose remote failures` — parity for Python.

## Release chain

Per the plan in #284, SDK lands first → tag `sdk/go/vX.Y.Z` and the Python package → follow-up PRs bump the CLI's SDK pin and update the MCP handler to unwrap `FallbackError` and surface an appropriate message to the agent.

## Follow-up already filed

- #287 — Drain loops on duplicate IDs after network split during propose. The server's `/propose` should be idempotent on ID conflict; today a drained unit that already exists on the remote gets a 500, is classified as unreachable, and retries forever. Expanded surface area because of this PR's broader fallback scope.

## Test plan

- [ ] `make lint` — green.
- [ ] `make test` — Go 273 + Python 276 + CLI 44 + server 190 + frontend 11, all passing.
- [ ] Go: `TestProposeRemoteUnreachable` verifies `FallbackError` with `errors.Is(fb.Err, errUnreachable)`.
- [ ] Go: `TestProposeRemoteAuthRejectFallsBackLocally` covers 401 + 403 subtests.
- [ ] Go: `TestFallbackErrorMessage` verifies `.Error()` output for both RemoteError and sentinel causes.
- [ ] Python: `test_propose_auth_reject_falls_back_to_local` parametrised over 401/403.
- [ ] Python: `test_propose_falls_back_to_local_when_remote_unreachable` verifies transport fallback raises `FallbackError`.
- [ ] Python: `test_fallback_error_message_and_cause` verifies `str(fb)` output and `__cause__` chain.

Fixes #284.