### PR TITLE
Fix ARM64 binary download on Linux and Windows

### DIFF
--- a/plugins/cq/scripts/cq_binary.py
+++ b/plugins/cq/scripts/cq_binary.py
@@ -67,6 +67,7 @@ def download(version: str, system: str, bin_dir: Path, binary: Path) -> None:
         "AMD64": "x86_64",
         "x86_64": "x86_64",
         "arm64": "arm64",
+        "ARM64": "arm64",  # platform.machine() returns "ARM64" on native Windows ARM64.
         "aarch64": "arm64",  # Release assets use "arm64" on Linux, not "aarch64".
     }
     arch = arch_map.get(machine)

--- a/plugins/cq/scripts/cq_binary.py
+++ b/plugins/cq/scripts/cq_binary.py
@@ -67,7 +67,7 @@ def download(version: str, system: str, bin_dir: Path, binary: Path) -> None:
         "AMD64": "x86_64",
         "x86_64": "x86_64",
         "arm64": "arm64",
-        "aarch64": "aarch64",
+        "aarch64": "arm64",  # Release assets use "arm64" on Linux, not "aarch64".
     }
     arch = arch_map.get(machine)
     if not arch:

--- a/plugins/cq/tests/test_cq_binary.py
+++ b/plugins/cq/tests/test_cq_binary.py
@@ -289,3 +289,26 @@ def test_download_constructs_correct_url_for_aarch64_on_linux(cq_binary, monkeyp
         cq_binary.download("0.2.2", "Linux", bin_dir, binary)
 
     assert captured_url == "https://github.com/mozilla-ai/cq/releases/download/cli/v0.2.2/cq_Linux_arm64.tar.gz"
+
+
+def test_download_constructs_correct_url_for_arm64_on_windows(cq_binary, monkeypatch, tmp_path):
+    """Verify native Windows ARM64 hosts (platform.machine() == "ARM64") download arm64 binaries."""
+    bin_dir = tmp_path / "bin"
+    binary = bin_dir / "cq.exe"
+
+    monkeypatch.setattr(cq_binary.platform, "machine", lambda: "ARM64")
+    monkeypatch.setattr(cq_binary.platform, "system", lambda: "Windows")
+
+    captured_url = None
+
+    def _fake_urlretrieve(url, path):
+        nonlocal captured_url
+        captured_url = url
+
+    monkeypatch.setattr(cq_binary.urllib.request, "urlretrieve", _fake_urlretrieve)
+    monkeypatch.setattr(cq_binary.zipfile, "ZipFile", lambda *_a, **_k: None)
+
+    with contextlib.suppress(TypeError):
+        cq_binary.download("0.2.2", "Windows", bin_dir, binary)
+
+    assert captured_url == "https://github.com/mozilla-ai/cq/releases/download/cli/v0.2.2/cq_Windows_arm64.zip"

--- a/plugins/cq/tests/test_cq_binary.py
+++ b/plugins/cq/tests/test_cq_binary.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from importlib import util
 from pathlib import Path
 from types import ModuleType
@@ -265,3 +266,26 @@ def test_ensure_binary_unlinks_broken_symlink_before_resolving(cq_binary, monkey
 
     assert binary.exists()
     assert binary.resolve() == real_cq.resolve()
+
+
+def test_download_constructs_correct_url_for_aarch64_on_linux(cq_binary, monkeypatch, tmp_path):
+    """Verify that aarch64 machines download arm64 binaries."""
+    bin_dir = tmp_path / "bin"
+    binary = bin_dir / "cq"
+
+    monkeypatch.setattr(cq_binary.platform, "machine", lambda: "aarch64")
+    monkeypatch.setattr(cq_binary.platform, "system", lambda: "Linux")
+
+    captured_url = None
+
+    def _fake_urlretrieve(url, path):
+        nonlocal captured_url
+        captured_url = url
+
+    monkeypatch.setattr(cq_binary.urllib.request, "urlretrieve", _fake_urlretrieve)
+    monkeypatch.setattr(cq_binary.tarfile, "open", lambda *_a, **_k: None)
+
+    with contextlib.suppress(TypeError):
+        cq_binary.download("0.2.2", "Linux", bin_dir, binary)
+
+    assert captured_url == "https://github.com/mozilla-ai/cq/releases/download/cli/v0.2.2/cq_Linux_arm64.tar.gz"


### PR DESCRIPTION
## Summary

- Cherry-picks @aiven-amartin's aarch64 fix from [Aiven-Labs/cq#1](https://github.com/Aiven-Labs/cq/pull/1) (originally surfaced via #274). Linux aarch64 hosts were mapped to a non-existent `cq_Linux_aarch64.tar.gz` release asset; the release uses `arm64` naming.
- Adds a matching fix for native Windows ARM64 (`platform.machine() == "ARM64"`), which had the same symptom against `cq_Windows_arm64.zip`.
- Adds tests for both URL constructions.

Credit to @aiven-amartin for the original diagnosis and patch.

## Test plan

- [x] `make lint` passes.
- [x] `make test` passes (190 tests).
- [ ] Manual download on a Linux aarch64 host.
- [ ] Manual download on a native Windows ARM64 host.