### PR TITLE
Bump SDK version used by CLI to v0.4.0

### DIFF
--- a/cli/cmd/propose.go
+++ b/cli/cmd/propose.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -48,6 +49,13 @@ func NewProposeCmd() *cobra.Command {
 				Frameworks: frameworks,
 				Pattern:    pattern,
 			})
+			// Remote unreachable/rejected: unit was stored locally. Warn but succeed.
+			var fb *cq.FallbackError
+			if errors.As(err, &fb) {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s\n", err)
+				ku = fb.LocalUnit
+				err = nil
+			}
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/propose_test.go
+++ b/cli/cmd/propose_test.go
@@ -41,3 +41,25 @@ func TestProposeTextFormat(t *testing.T) {
 	require.NoError(t, propose.Execute())
 	require.Contains(t, buf.String(), "Proposed: ku_")
 }
+
+// When a remote is configured but unreachable, propose must still succeed
+// (unit stored locally) and surface a warning on stderr.
+func TestProposeRemoteUnreachableWarns(t *testing.T) {
+	testSetup(t)
+	setFlag(t, &flagAddr, "http://127.0.0.1:1")
+
+	propose := NewProposeCmd()
+	var out, errBuf bytes.Buffer
+	propose.SetOut(&out)
+	propose.SetErr(&errBuf)
+	propose.SetArgs([]string{
+		"--summary", "fallback",
+		"--detail", "d",
+		"--action", "a",
+		"--domain", "test",
+	})
+	require.NoError(t, propose.Execute())
+	require.Contains(t, out.String(), "Proposed: ku_")
+	require.Contains(t, errBuf.String(), "warning:")
+	require.Contains(t, errBuf.String(), "stored locally after remote failure")
+}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/mark3labs/mcp-go v0.46.0
-	github.com/mozilla-ai/cq/sdk/go v0.3.0
+	github.com/mozilla-ai/cq/sdk/go v0.4.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9
 	github.com/stretchr/testify v1.11.1

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -25,8 +25,8 @@ github.com/mark3labs/mcp-go v0.46.0 h1:8KRibF4wcKejbLsHxCA/QBVUr5fQ9nwz/n8lGqmaA
 github.com/mark3labs/mcp-go v0.46.0/go.mod h1:JKTC7R2LLVagkEWK7Kwu7DbmA6iIvnNAod6yrHiQMag=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/mozilla-ai/cq/sdk/go v0.3.0 h1:p465l6jOb0w0uKsQunmNolS/hZ46SRUfVSmzY/NYGzI=
-github.com/mozilla-ai/cq/sdk/go v0.3.0/go.mod h1:gqXCbhabJXzN+UT8kfmhUcLYrfcaWDP45XgmQf4baN0=
+github.com/mozilla-ai/cq/sdk/go v0.4.0 h1:GICFnPfayescU6xbj0/zI+LlqnGRczdxh6AvWkli0gk=
+github.com/mozilla-ai/cq/sdk/go v0.4.0/go.mod h1:gqXCbhabJXzN+UT8kfmhUcLYrfcaWDP45XgmQf4baN0=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/cli/mcpserver/propose.go
+++ b/cli/mcpserver/propose.go
@@ -3,6 +3,7 @@ package mcpserver
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -76,6 +77,17 @@ func (s *Server) HandlePropose(ctx context.Context, req mcp.CallToolRequest) (*m
 	}
 
 	result, err := s.client.Propose(ctx, params)
+	// Remote unreachable/rejected: unit was stored locally. Surface the unit
+	// alongside a warning so the caller can summarise the partial success.
+	var fb *cq.FallbackError
+	if errors.As(err, &fb) {
+		data, mErr := json.Marshal(fb.LocalUnit)
+		if mErr != nil {
+			return nil, fmt.Errorf("encoding result: %w", mErr)
+		}
+
+		return mcp.NewToolResultText(fmt.Sprintf("warning: %s\n%s", fb, data)), nil
+	}
 	if err != nil {
 		return nil, fmt.Errorf("proposing: %w", err)
 	}

--- a/cli/mcpserver/propose_test.go
+++ b/cli/mcpserver/propose_test.go
@@ -3,6 +3,7 @@ package mcpserver
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -112,6 +113,72 @@ func TestHandlePropose(t *testing.T) {
 				require.Equal(t, tc.wantMsg, result.Content[0].(mcp.TextContent).Text)
 			})
 		}
+	})
+
+	t.Run("surfaces fallback warning when remote unreachable", func(t *testing.T) {
+		t.Parallel()
+
+		localUnit := cq.KnowledgeUnit{ID: "ku_0123456789abcdef0123456789abcdef"}
+		s := New(&mockClient{
+			proposeFn: func(_ context.Context, _ cq.ProposeParams) (cq.KnowledgeUnit, error) {
+				return cq.KnowledgeUnit{}, &cq.FallbackError{
+					LocalUnit: localUnit,
+					Err:       errors.New("remote API unreachable: connection refused"),
+				}
+			},
+		}, "test")
+
+		result, err := s.HandlePropose(context.Background(), mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name: "propose",
+				Arguments: map[string]any{
+					"summary": "s",
+					"detail":  "d",
+					"action":  "a",
+					"domains": []any{"api"},
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		require.Contains(t, text, "warning: stored locally after remote failure")
+		require.Contains(t, text, "remote API unreachable: connection refused")
+		require.Contains(t, text, "ku_0123456789abcdef0123456789abcdef")
+	})
+
+	t.Run("surfaces fallback warning when remote rejects with RemoteError", func(t *testing.T) {
+		t.Parallel()
+
+		localUnit := cq.KnowledgeUnit{ID: "ku_fedcba9876543210fedcba9876543210"}
+		s := New(&mockClient{
+			proposeFn: func(_ context.Context, _ cq.ProposeParams) (cq.KnowledgeUnit, error) {
+				return cq.KnowledgeUnit{}, &cq.FallbackError{
+					LocalUnit: localUnit,
+					Err:       &cq.RemoteError{StatusCode: 401, Detail: "Invalid API key"},
+				}
+			},
+		}, "test")
+
+		result, err := s.HandlePropose(context.Background(), mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name: "propose",
+				Arguments: map[string]any{
+					"summary": "s",
+					"detail":  "d",
+					"action":  "a",
+					"domains": []any{"api"},
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		require.Contains(t, text, "warning: stored locally after remote failure")
+		require.Contains(t, text, "remote API rejected request (401): Invalid API key")
+		require.Contains(t, text, "ku_fedcba9876543210fedcba9876543210")
 	})
 
 	t.Run("empty domains slice yields distinct message", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Bump CLI's `sdk/go` pin to v0.4.0 (brings the new fallback-on-remote-failure behaviour).
- Adapt `propose` command to the new SDK contract: when the SDK returns `*cq.FallbackError`, emit a warning on stderr, return the locally-stored unit, and exit 0. Old behaviour (silent local fallback) is preserved for end users.
- Adapt the MCP server `propose` tool handler similarly: when the SDK returns `*cq.FallbackError`, surface a `warning: stored locally after remote failure: <cause>` line prepended to the unit JSON in the tool result, so LLM callers can summarise the partial success rather than seeing a hard tool failure.
- Tests cover both fallback modes — transport unreachable and `RemoteError` (e.g. 401 auth reject).

## Test plan

- [x] `make test`
- [x] `make lint`
- [x] New CLI test `TestProposeRemoteUnreachableWarns`
- [x] New MCP tests `TestHandlePropose/surfaces_fallback_warning_when_remote_unreachable` + `.../surfaces_fallback_warning_when_remote_rejects_with_RemoteError`