### PR TITLE
Refactor API key auth: versioned tokens, POST /revoke, list envelope

### DIFF
--- a/server/backend/src/cq_server/api_keys.py
+++ b/server/backend/src/cq_server/api_keys.py
@@ -20,6 +20,8 @@ TOKEN_NAMESPACE = "cqa"
 TOKEN_VERSION = "v1"
 
 _SECRET_BYTES = 32
+_SECRET_LENGTH = 52  # 32 bytes encoded as unpadded lowercase base32.
+_SECRET_ALPHABET = frozenset("abcdefghijklmnopqrstuvwxyz234567")
 _SECRET_PREFIX_LENGTH = 8
 _TOKEN_PART_COUNT = 4
 
@@ -64,8 +66,10 @@ def decode_token(token: str) -> tuple[uuid.UUID, str]:
     if len(parts) != _TOKEN_PART_COUNT:
         raise ValueError("token format is invalid")
     namespace, version, key_id_hex, secret = parts
-    if namespace != TOKEN_NAMESPACE or version != TOKEN_VERSION or not secret:
+    if namespace != TOKEN_NAMESPACE or version != TOKEN_VERSION:
         raise ValueError("token format is invalid")
+    if len(secret) != _SECRET_LENGTH or not all(c in _SECRET_ALPHABET for c in secret):
+        raise ValueError("token secret is malformed")
     try:
         key_id = uuid.UUID(hex=key_id_hex)
     except ValueError as exc:
@@ -90,7 +94,9 @@ def secret_prefix(secret: str) -> str:
     """Return the stored display prefix for a secret.
 
     The prefix is the first ``_SECRET_PREFIX_LENGTH`` characters of the
-    secret; enough to distinguish keys in UI listings without revealing
-    any material that could be used for authentication.
+    secret; enough to distinguish keys in UI listings while exposing
+    only a small portion that does not meaningfully weaken security:
+    8 of 52 base32 characters leaves ~220 bits of entropy in the
+    unexposed tail, which remains infeasible to brute-force.
     """
     return secret[:_SECRET_PREFIX_LENGTH]

--- a/server/backend/src/cq_server/api_keys.py
+++ b/server/backend/src/cq_server/api_keys.py
@@ -1,49 +1,96 @@
-"""API key token generation and hashing.
+"""API key token encoding and hashing.
 
-Tokens are random 256-bit values encoded as lowercase base32 and prefixed
-with a stable identifier (``cqa_``) so they are easy to recognise in logs
-and pick up with secret-scanning rules. Hashing uses HMAC-SHA256 with a
-server-side pepper.
+Tokens follow a versioned, dot-separated format so the key's database row
+can be located by identifier rather than by hashing the entire plaintext.
+This lets the server store only a hash of the random secret component and
+compare it to the presented secret in constant time.
+
+Format: ``{NAMESPACE}.{VERSION}.{key_id_hex}.{secret}``
+
+Hashing uses HMAC-SHA256 with a server-side pepper over the secret only.
 """
 
 import base64
 import hmac
 import secrets
+import uuid
 from hashlib import sha256
 
-PREFIX = "cqa_"
-_TOKEN_BYTES = 32
-_PREFIX_DISPLAY_LENGTH = 8
+TOKEN_NAMESPACE = "cqa"
+TOKEN_VERSION = "v1"
+
+_SECRET_BYTES = 32
+_SECRET_PREFIX_LENGTH = 8
+_TOKEN_PART_COUNT = 4
 
 
-def generate_plaintext() -> str:
-    """Return a fresh random API key plaintext.
+def generate_secret() -> str:
+    """Return a fresh random secret string for use as an API key secret.
 
-    The token is ``PREFIX`` followed by 52 lowercase base32 characters
-    encoding 32 random bytes (256 bits of entropy).
+    The secret is 52 lowercase base32 characters encoding 32 random bytes
+    (256 bits of entropy). It is the secret component of the full token
+    and is never stored in plaintext.
     """
-    raw = secrets.token_bytes(_TOKEN_BYTES)
-    encoded = base64.b32encode(raw).decode("ascii").rstrip("=").lower()
-    return f"{PREFIX}{encoded}"
+    raw = secrets.token_bytes(_SECRET_BYTES)
+    return base64.b32encode(raw).decode("ascii").rstrip("=").lower()
 
 
-def hash_token(plaintext: str, *, pepper: str) -> str:
-    """Return the HMAC-SHA256 hex digest of the plaintext under the pepper.
+def encode_token(*, key_id: uuid.UUID, secret: str) -> str:
+    """Encode a key id and secret into the public token string.
 
     Args:
-        plaintext: The full plaintext token, including the ``cqa_`` prefix.
+        key_id: The API key's identifier.
+        secret: The random secret component produced by ``generate_secret``.
+
+    Returns:
+        A dot-separated token of the form ``cqa.v1.<hex>.<secret>``.
+    """
+    return f"{TOKEN_NAMESPACE}.{TOKEN_VERSION}.{key_id.hex}.{secret}"
+
+
+def decode_token(token: str) -> tuple[uuid.UUID, str]:
+    """Parse a plaintext token into its key id and secret components.
+
+    Args:
+        token: The full plaintext token presented by the caller.
+
+    Returns:
+        The ``(key_id, secret)`` pair encoded in the token.
+
+    Raises:
+        ValueError: If the token does not match the expected format.
+    """
+    parts = token.split(".")
+    if len(parts) != _TOKEN_PART_COUNT:
+        raise ValueError("token format is invalid")
+    namespace, version, key_id_hex, secret = parts
+    if namespace != TOKEN_NAMESPACE or version != TOKEN_VERSION or not secret:
+        raise ValueError("token format is invalid")
+    try:
+        key_id = uuid.UUID(hex=key_id_hex)
+    except ValueError as exc:
+        raise ValueError("token key id is not a valid UUID") from exc
+    return key_id, secret
+
+
+def hash_secret(secret: str, *, pepper: str) -> str:
+    """Return the HMAC-SHA256 hex digest of the secret under the pepper.
+
+    Args:
+        secret: The random secret component of an API key token.
         pepper: Server-side secret used as the HMAC key.
 
     Returns:
         A 64-character hex string.
     """
-    return hmac.new(pepper.encode("utf-8"), plaintext.encode("utf-8"), sha256).hexdigest()
+    return hmac.new(pepper.encode("utf-8"), secret.encode("utf-8"), sha256).hexdigest()
 
 
-def token_prefix(plaintext: str) -> str:
-    """Return the stored display prefix for a plaintext token.
+def secret_prefix(secret: str) -> str:
+    """Return the stored display prefix for a secret.
 
-    This is the first ``_PREFIX_DISPLAY_LENGTH`` characters — enough to
-    distinguish keys in UI listings without exposing the secret.
+    The prefix is the first ``_SECRET_PREFIX_LENGTH`` characters of the
+    secret; enough to distinguish keys in UI listings without revealing
+    any material that could be used for authentication.
     """
-    return plaintext[:_PREFIX_DISPLAY_LENGTH]
+    return secret[:_SECRET_PREFIX_LENGTH]

--- a/server/backend/src/cq_server/auth.py
+++ b/server/backend/src/cq_server/auth.py
@@ -65,6 +65,12 @@ class MeResponse(BaseModel):
     created_at: str
 
 
+class Message(BaseModel):
+    """Generic message response body."""
+
+    message: str
+
+
 class CreateApiKeyRequest(BaseModel):
     """Request body for creating an API key."""
 
@@ -276,19 +282,21 @@ def list_api_keys_route(
     return [_to_public(row) for row in store.list_api_keys_for_user(user_id)]
 
 
-@router.delete("/api-keys/{key_id}", status_code=204)
+@router.post("/api-keys/{key_id}/revoke")
 def revoke_api_key_route(
     key_id: str,
     username: str = Depends(get_current_user),
     store: RemoteStore = Depends(get_store),
-) -> None:
+) -> Message:
     """Revoke the given API key if it belongs to the caller.
 
-    Revocation is idempotent: revoking a key that is already revoked returns
-    204. A 404 is returned only when the key does not exist or is owned by
-    a different user (uniform response, no enumeration oracle).
+    Revocation is a state transition; the row is retained with
+    ``revoked_at`` set. Repeated revocations are idempotent and succeed.
+    A 404 is returned when the key does not exist or is owned by a
+    different user (uniform response, no enumeration oracle).
     """
     user_id = _require_user_id(store, username)
     if store.get_api_key_for_user(user_id=user_id, key_id=key_id) is None:
         raise HTTPException(status_code=404, detail="API key not found")
     store.revoke_api_key(user_id=user_id, key_id=key_id)
+    return Message(message="API key revoked.")

--- a/server/backend/src/cq_server/auth.py
+++ b/server/backend/src/cq_server/auth.py
@@ -101,6 +101,17 @@ class CreateApiKeyResponse(ApiKeyPublic):
     token: str
 
 
+class ApiKeysPublic(BaseModel):
+    """Collection wrapper for API key listings.
+
+    The envelope shape leaves room for pagination metadata (e.g. a
+    ``next_cursor`` field) without breaking existing clients.
+    """
+
+    data: list[ApiKeyPublic]
+    count: int
+
+
 def _to_public(row: dict[str, Any]) -> ApiKeyPublic:
     """Build the public view of an API key row."""
     now = datetime.now(UTC)
@@ -276,10 +287,15 @@ def create_api_key_route(
 def list_api_keys_route(
     username: str = Depends(get_current_user),
     store: RemoteStore = Depends(get_store),
-) -> list[ApiKeyPublic]:
-    """Return the authenticated user's API keys. Never returns plaintext."""
+) -> ApiKeysPublic:
+    """Return the authenticated user's API keys. Never returns plaintext.
+
+    Revoked keys are included with ``is_active: false`` so users can audit
+    their own revocation history.
+    """
     user_id = _require_user_id(store, username)
-    return [_to_public(row) for row in store.list_api_keys_for_user(user_id)]
+    data = [_to_public(row) for row in store.list_api_keys_for_user(user_id)]
+    return ApiKeysPublic(data=data, count=len(data))
 
 
 @router.post("/api-keys/{key_id}/revoke")

--- a/server/backend/src/cq_server/auth.py
+++ b/server/backend/src/cq_server/auth.py
@@ -10,7 +10,7 @@ import jwt
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
-from .api_keys import generate_plaintext, hash_token, token_prefix
+from .api_keys import encode_token, generate_secret, hash_secret, secret_prefix
 from .deps import get_api_key_pepper, get_store
 from .store import RemoteStore
 from .ttl import parse_ttl
@@ -248,15 +248,17 @@ def create_api_key_route(
             status_code=409,
             detail=f"Maximum of {MAX_ACTIVE_API_KEYS_PER_USER} active API keys per user",
         )
-    plaintext = generate_plaintext()
+    key_id = uuid.uuid4()
+    secret = generate_secret()
+    plaintext = encode_token(key_id=key_id, secret=secret)
     expires_at = (datetime.now(UTC) + duration).isoformat()
     row = store.create_api_key(
-        key_id=uuid.uuid4().hex,
+        key_id=key_id.hex,
         user_id=user_id,
         name=request.name,
         labels=_normalise_labels(request.labels),
-        key_prefix=token_prefix(plaintext),
-        key_hash=hash_token(plaintext, pepper=pepper),
+        key_prefix=secret_prefix(secret),
+        key_hash=hash_secret(secret, pepper=pepper),
         ttl=request.ttl,
         expires_at=expires_at,
     )

--- a/server/backend/src/cq_server/deps.py
+++ b/server/backend/src/cq_server/deps.py
@@ -1,10 +1,10 @@
 """FastAPI dependencies shared across routers."""
 
-from datetime import UTC, datetime
+import hmac
 
 from fastapi import BackgroundTasks, Depends, HTTPException, Request
 
-from .api_keys import PREFIX, hash_token
+from .api_keys import decode_token, hash_secret
 from .store import RemoteStore
 
 API_KEY_PEPPER_ENV = "CQ_API_KEY_PEPPER"  # pragma: allowlist secret
@@ -42,7 +42,10 @@ def require_api_key(
     """Authenticate an API key and return the owning user's username.
 
     The ``Authorization: Bearer <token>`` header must carry a valid,
-    unrevoked, unexpired key.
+    unrevoked, unexpired key. The token is decoded to its key id and
+    secret components; the stored hash of the secret is compared to a
+    fresh HMAC of the presented secret using ``hmac.compare_digest`` to
+    avoid timing side channels.
 
     Args:
         request: The incoming FastAPI request.
@@ -59,13 +62,15 @@ def require_api_key(
     if not header or not header.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Invalid API key")
     token = header.removeprefix("Bearer ")
-    if not token.startswith(PREFIX):
-        raise HTTPException(status_code=401, detail="Invalid API key")
+    try:
+        key_id, secret = decode_token(token)
+    except ValueError as exc:
+        raise HTTPException(status_code=401, detail="Invalid API key") from exc
     pepper = get_api_key_pepper(request)
-    row = store.get_api_key_by_hash(hash_token(token, pepper=pepper))
-    if row is None or row["revoked_at"] is not None:
+    row = store.get_active_api_key_by_id(key_id.hex)
+    if row is None:
         raise HTTPException(status_code=401, detail="Invalid API key")
-    if datetime.fromisoformat(row["expires_at"]) <= datetime.now(UTC):
+    if not hmac.compare_digest(row["key_hash"], hash_secret(secret, pepper=pepper)):
         raise HTTPException(status_code=401, detail="Invalid API key")
     background_tasks.add_task(store.touch_api_key_last_used, row["id"])
     return row["username"]

--- a/server/backend/src/cq_server/store.py
+++ b/server/backend/src/cq_server/store.py
@@ -617,24 +617,31 @@ class RemoteStore:
             "revoked_at": row[9],
         }
 
-    def get_api_key_by_hash(self, key_hash: str) -> dict[str, Any] | None:
-        """Retrieve an API key row by its hash, including the owner's username.
+    def get_active_api_key_by_id(self, key_id: str) -> dict[str, Any] | None:
+        """Retrieve an active API key row by id, including the owner's username.
+
+        "Active" means the same thing as in ``count_active_api_keys_for_user``:
+        not revoked and not yet expired. The caller is expected to compare
+        the stored ``key_hash`` against a fresh hash of the presented
+        secret in constant time.
 
         Args:
-            key_hash: HMAC-SHA256 hex digest of the plaintext token.
+            key_id: The key's id (uuid4 hex).
 
         Returns:
-            A dict with api key fields plus the owner's username, or None
-            if no key with that hash exists.
+            A dict with api key fields (including ``key_hash``) plus the
+            owner's username, or None if the key does not exist, has
+            been revoked, or has expired.
         """
         self._check_open()
+        now = datetime.now(UTC).isoformat()
         with self._lock:
             row = self._conn.execute(
                 "SELECT k.id, k.user_id, u.username, k.name, k.labels, k.key_prefix, "
-                "k.ttl, k.expires_at, k.created_at, k.last_used_at, k.revoked_at "
+                "k.key_hash, k.ttl, k.expires_at, k.created_at, k.last_used_at, k.revoked_at "
                 "FROM api_keys k JOIN users u ON u.id = k.user_id "
-                "WHERE k.key_hash = ?",
-                (key_hash,),
+                "WHERE k.id = ? AND k.revoked_at IS NULL AND k.expires_at > ?",
+                (key_id, now),
             ).fetchone()
         if row is None:
             return None
@@ -645,11 +652,12 @@ class RemoteStore:
             "name": row[3],
             "labels": json.loads(row[4] or "[]"),
             "key_prefix": row[5],
-            "ttl": row[6],
-            "expires_at": row[7],
-            "created_at": row[8],
-            "last_used_at": row[9],
-            "revoked_at": row[10],
+            "key_hash": row[6],
+            "ttl": row[7],
+            "expires_at": row[8],
+            "created_at": row[9],
+            "last_used_at": row[10],
+            "revoked_at": row[11],
         }
 
     def list_api_keys_for_user(self, user_id: int) -> list[dict[str, Any]]:

--- a/server/backend/tests/test_api_keys.py
+++ b/server/backend/tests/test_api_keys.py
@@ -62,8 +62,23 @@ class TestDecodeToken:
             decode_token(f"{TOKEN_NAMESPACE}.{TOKEN_VERSION}.{uuid.uuid4().hex}.")
 
     def test_rejects_bad_uuid(self) -> None:
+        valid_secret = "a" * 52
         with pytest.raises(ValueError):
-            decode_token(f"{TOKEN_NAMESPACE}.{TOKEN_VERSION}.not-a-uuid.sekret")
+            decode_token(f"{TOKEN_NAMESPACE}.{TOKEN_VERSION}.not-a-uuid.{valid_secret}")
+
+    def test_rejects_secret_wrong_length(self) -> None:
+        short = "a" * 10
+        long = "a" * 100
+        with pytest.raises(ValueError):
+            decode_token(f"{TOKEN_NAMESPACE}.{TOKEN_VERSION}.{uuid.uuid4().hex}.{short}")
+        with pytest.raises(ValueError):
+            decode_token(f"{TOKEN_NAMESPACE}.{TOKEN_VERSION}.{uuid.uuid4().hex}.{long}")
+
+    def test_rejects_secret_bad_charset(self) -> None:
+        # Uppercase is outside the lowercase base32 alphabet.
+        bad = "A" * 52
+        with pytest.raises(ValueError):
+            decode_token(f"{TOKEN_NAMESPACE}.{TOKEN_VERSION}.{uuid.uuid4().hex}.{bad}")
 
 
 class TestHashSecret:

--- a/server/backend/tests/test_api_keys.py
+++ b/server/backend/tests/test_api_keys.py
@@ -1,45 +1,90 @@
-"""Tests for API key token generation and hashing."""
+"""Tests for API key token encoding and hashing."""
 
-from cq_server.api_keys import PREFIX, generate_plaintext, hash_token, token_prefix
+import uuid
+
+import pytest
+
+from cq_server.api_keys import (
+    TOKEN_NAMESPACE,
+    TOKEN_VERSION,
+    decode_token,
+    encode_token,
+    generate_secret,
+    hash_secret,
+    secret_prefix,
+)
 
 
-class TestGeneratePlaintext:
-    def test_starts_with_prefix(self) -> None:
-        assert generate_plaintext().startswith(PREFIX)
-
+class TestGenerateSecret:
     def test_is_unique(self) -> None:
-        tokens = {generate_plaintext() for _ in range(100)}
-        assert len(tokens) == 100
+        secrets_set = {generate_secret() for _ in range(100)}
+        assert len(secrets_set) == 100
 
     def test_length(self) -> None:
-        # 4-char prefix plus 52 base32 chars for 32 bytes (256 bits) without padding.
-        assert len(generate_plaintext()) == len(PREFIX) + 52
+        # 52 base32 characters encode 32 bytes (256 bits) without padding.
+        assert len(generate_secret()) == 52
 
     def test_body_is_lowercase_base32(self) -> None:
-        body = generate_plaintext().removeprefix(PREFIX)
+        body = generate_secret()
         assert body == body.lower()
         assert set(body).issubset(set("abcdefghijklmnopqrstuvwxyz234567"))  # pragma: allowlist secret
 
 
-class TestHashToken:
+class TestEncodeToken:
+    def test_format(self) -> None:
+        key_id = uuid.UUID("11111111222233334444555566667777")
+        token = encode_token(key_id=key_id, secret="sekret")
+        assert token == f"{TOKEN_NAMESPACE}.{TOKEN_VERSION}.{key_id.hex}.sekret"
+
+    def test_round_trip(self) -> None:
+        key_id = uuid.uuid4()
+        secret = generate_secret()
+        decoded_id, decoded_secret = decode_token(encode_token(key_id=key_id, secret=secret))
+        assert decoded_id == key_id
+        assert decoded_secret == secret
+
+
+class TestDecodeToken:
+    def test_rejects_wrong_part_count(self) -> None:
+        with pytest.raises(ValueError):
+            decode_token("cqa.v1.deadbeef")
+
+    def test_rejects_wrong_namespace(self) -> None:
+        with pytest.raises(ValueError):
+            decode_token(f"other.{TOKEN_VERSION}.{uuid.uuid4().hex}.sekret")
+
+    def test_rejects_wrong_version(self) -> None:
+        with pytest.raises(ValueError):
+            decode_token(f"{TOKEN_NAMESPACE}.v0.{uuid.uuid4().hex}.sekret")
+
+    def test_rejects_empty_secret(self) -> None:
+        with pytest.raises(ValueError):
+            decode_token(f"{TOKEN_NAMESPACE}.{TOKEN_VERSION}.{uuid.uuid4().hex}.")
+
+    def test_rejects_bad_uuid(self) -> None:
+        with pytest.raises(ValueError):
+            decode_token(f"{TOKEN_NAMESPACE}.{TOKEN_VERSION}.not-a-uuid.sekret")
+
+
+class TestHashSecret:
     def test_deterministic(self) -> None:
-        assert hash_token("cqa_xyz", pepper="p") == hash_token("cqa_xyz", pepper="p")
+        assert hash_secret("xyz", pepper="p") == hash_secret("xyz", pepper="p")
 
     def test_different_peppers_produce_different_hashes(self) -> None:
-        assert hash_token("cqa_xyz", pepper="p1") != hash_token("cqa_xyz", pepper="p2")
+        assert hash_secret("xyz", pepper="p1") != hash_secret("xyz", pepper="p2")
 
-    def test_different_tokens_produce_different_hashes(self) -> None:
-        assert hash_token("cqa_a", pepper="p") != hash_token("cqa_b", pepper="p")
+    def test_different_secrets_produce_different_hashes(self) -> None:
+        assert hash_secret("a", pepper="p") != hash_secret("b", pepper="p")
 
     def test_hex_length(self) -> None:
-        digest = hash_token("cqa_xyz", pepper="p")
+        digest = hash_secret("xyz", pepper="p")
         assert len(digest) == 64
         int(digest, 16)  # Raises if not valid hex.
 
 
-class TestTokenPrefix:
+class TestSecretPrefix:
     def test_first_eight_chars(self) -> None:
-        assert token_prefix("cqa_abcdefg") == "cqa_abcd"
+        assert secret_prefix("abcdefghijklmnop") == "abcdefgh"
 
     def test_exact_eight(self) -> None:
-        assert token_prefix("12345678") == "12345678"
+        assert secret_prefix("12345678") == "12345678"

--- a/server/backend/tests/test_app.py
+++ b/server/backend/tests/test_app.py
@@ -447,8 +447,8 @@ class TestApiKeyEnforcement:
         )
         body = create_resp.json()
         api_token = body["token"]
-        enforced_client.delete(
-            f"/auth/api-keys/{body['id']}",
+        enforced_client.post(
+            f"/auth/api-keys/{body['id']}/revoke",
             headers={"Authorization": f"Bearer {jwt_token}"},
         )
         resp = enforced_client.post(

--- a/server/backend/tests/test_app.py
+++ b/server/backend/tests/test_app.py
@@ -482,7 +482,7 @@ class TestApiKeyEnforcement:
             "/auth/api-keys",
             headers={"Authorization": f"Bearer {jwt_token}"},
         ).json()
-        assert listed[0]["last_used_at"] is None
+        assert listed["data"][0]["last_used_at"] is None
 
         enforced_client.post(
             "/propose",
@@ -494,7 +494,7 @@ class TestApiKeyEnforcement:
             "/auth/api-keys",
             headers={"Authorization": f"Bearer {jwt_token}"},
         ).json()
-        assert listed_after[0]["last_used_at"] is not None
+        assert listed_after["data"][0]["last_used_at"] is not None
 
     def test_confirm_and_flag_require_api_key(self, enforced_client: TestClient) -> None:
         jwt_token = _seed_user_and_login(enforced_client)

--- a/server/backend/tests/test_auth.py
+++ b/server/backend/tests/test_auth.py
@@ -142,9 +142,13 @@ class TestApiKeyCreate:
         )
         assert resp.status_code == 201
         body = resp.json()
-        assert body["token"].startswith("cqa_")
+        parts = body["token"].split(".")
+        assert parts[0] == "cqa"
+        assert parts[1] == "v1"
+        assert len(parts[2]) == 32
+        assert len(parts[3]) == 52
+        assert body["prefix"] == parts[3][:8]
         assert body["name"] == "laptop"
-        assert body["prefix"].startswith("cqa_")
         assert body["is_active"] is True
         assert body["is_expired"] is False
 

--- a/server/backend/tests/test_auth.py
+++ b/server/backend/tests/test_auth.py
@@ -201,10 +201,11 @@ class TestApiKeyList:
         )
         resp = api_key_client.get("/auth/api-keys", headers={"Authorization": f"Bearer {token}"})
         assert resp.status_code == 200
-        keys = resp.json()
-        assert len(keys) == 1
-        assert "token" not in keys[0]
-        assert keys[0]["name"] == "laptop"
+        body = resp.json()
+        assert body["count"] == 1
+        assert len(body["data"]) == 1
+        assert "token" not in body["data"][0]
+        assert body["data"][0]["name"] == "laptop"
 
     def test_list_requires_jwt(self, api_key_client: TestClient) -> None:
         resp = api_key_client.get("/auth/api-keys")
@@ -224,8 +225,9 @@ class TestApiKeyList:
             json={"name": "bob-key", "ttl": "30d"},
         )
         resp = api_key_client.get("/auth/api-keys", headers={"Authorization": f"Bearer {token_a}"})
-        names = [k["name"] for k in resp.json()]
-        assert names == ["alice-key"]
+        body = resp.json()
+        assert body["count"] == 1
+        assert [k["name"] for k in body["data"]] == ["alice-key"]
 
 
 class TestApiKeyRevoke:
@@ -243,9 +245,9 @@ class TestApiKeyRevoke:
         assert resp.status_code == 200
         assert resp.json() == {"message": "API key revoked."}
 
-        listed = api_key_client.get("/auth/api-keys", headers={"Authorization": f"Bearer {token}"}).json()
-        assert listed[0]["revoked_at"] is not None
-        assert listed[0]["is_active"] is False
+        body = api_key_client.get("/auth/api-keys", headers={"Authorization": f"Bearer {token}"}).json()
+        assert body["data"][0]["revoked_at"] is not None
+        assert body["data"][0]["is_active"] is False
 
     def test_revoke_is_idempotent(self, api_key_client: TestClient) -> None:
         token = _login(api_key_client)

--- a/server/backend/tests/test_auth.py
+++ b/server/backend/tests/test_auth.py
@@ -236,11 +236,12 @@ class TestApiKeyRevoke:
             headers={"Authorization": f"Bearer {token}"},
             json={"name": "x", "ttl": "30d"},
         ).json()
-        resp = api_key_client.delete(
-            f"/auth/api-keys/{created['id']}",
+        resp = api_key_client.post(
+            f"/auth/api-keys/{created['id']}/revoke",
             headers={"Authorization": f"Bearer {token}"},
         )
-        assert resp.status_code == 204
+        assert resp.status_code == 200
+        assert resp.json() == {"message": "API key revoked."}
 
         listed = api_key_client.get("/auth/api-keys", headers={"Authorization": f"Bearer {token}"}).json()
         assert listed[0]["revoked_at"] is not None
@@ -253,16 +254,16 @@ class TestApiKeyRevoke:
             headers={"Authorization": f"Bearer {token}"},
             json={"name": "x", "ttl": "30d"},
         ).json()
-        first = api_key_client.delete(
-            f"/auth/api-keys/{created['id']}",
+        first = api_key_client.post(
+            f"/auth/api-keys/{created['id']}/revoke",
             headers={"Authorization": f"Bearer {token}"},
         )
-        second = api_key_client.delete(
-            f"/auth/api-keys/{created['id']}",
+        second = api_key_client.post(
+            f"/auth/api-keys/{created['id']}/revoke",
             headers={"Authorization": f"Bearer {token}"},
         )
-        assert first.status_code == 204
-        assert second.status_code == 204
+        assert first.status_code == 200
+        assert second.status_code == 200
 
     def test_revoke_other_users_key_returns_404(self, api_key_client: TestClient) -> None:
         token_a = _login(api_key_client, username="alice")
@@ -272,20 +273,20 @@ class TestApiKeyRevoke:
             headers={"Authorization": f"Bearer {token_a}"},
             json={"name": "alice-key", "ttl": "30d"},
         ).json()
-        resp = api_key_client.delete(
-            f"/auth/api-keys/{created['id']}",
+        resp = api_key_client.post(
+            f"/auth/api-keys/{created['id']}/revoke",
             headers={"Authorization": f"Bearer {token_b}"},
         )
         assert resp.status_code == 404
 
     def test_revoke_unknown_key_returns_404(self, api_key_client: TestClient) -> None:
         token = _login(api_key_client)
-        resp = api_key_client.delete(
-            "/auth/api-keys/nonexistent",
+        resp = api_key_client.post(
+            "/auth/api-keys/nonexistent/revoke",
             headers={"Authorization": f"Bearer {token}"},
         )
         assert resp.status_code == 404
 
     def test_revoke_requires_jwt(self, api_key_client: TestClient) -> None:
-        resp = api_key_client.delete("/auth/api-keys/anything")
+        resp = api_key_client.post("/auth/api-keys/anything/revoke")
         assert resp.status_code == 401

--- a/server/backend/tests/test_deps.py
+++ b/server/backend/tests/test_deps.py
@@ -1,5 +1,6 @@
 """Tests for the shared FastAPI dependencies, including require_api_key."""
 
+import uuid
 from collections.abc import Iterator
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -8,7 +9,7 @@ import pytest
 from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
 
-from cq_server.api_keys import hash_token
+from cq_server.api_keys import encode_token, generate_secret, hash_secret
 from cq_server.deps import require_api_key
 
 
@@ -19,8 +20,13 @@ class _StubStore:
         self.rows = rows or {}
         self.touched: list[str] = []
 
-    def get_api_key_by_hash(self, key_hash: str) -> dict[str, Any] | None:
-        return self.rows.get(key_hash)
+    def get_active_api_key_by_id(self, key_id: str) -> dict[str, Any] | None:
+        row = self.rows.get(key_id)
+        if row is None or row.get("revoked_at") is not None:
+            return None
+        if datetime.fromisoformat(row["expires_at"]) <= datetime.now(UTC):
+            return None
+        return row
 
     def touch_api_key_last_used(self, key_id: str) -> None:
         self.touched.append(key_id)
@@ -31,18 +37,20 @@ PEPPER = "test-pepper"
 
 def _row(
     *,
-    key_id: str = "k1",
+    key_id: uuid.UUID,
+    secret: str,
     username: str = "alice",
     expires_at: datetime | None = None,
     revoked_at: datetime | None = None,
 ) -> dict[str, Any]:
     return {
-        "id": key_id,
+        "id": key_id.hex,
         "user_id": 1,
         "username": username,
         "name": "l",
         "labels": [],
-        "key_prefix": "cqa_abcd",
+        "key_prefix": secret[:8],
+        "key_hash": hash_secret(secret, pepper=PEPPER),
         "ttl": "30d",
         "expires_at": (expires_at or datetime.now(UTC) + timedelta(days=30)).isoformat(),
         "created_at": datetime.now(UTC).isoformat(),
@@ -65,26 +73,27 @@ def _app_with_store(store: _StubStore, *, pepper: str | None = PEPPER) -> FastAP
 
 
 @pytest.fixture()
-def token_and_store() -> Iterator[tuple[str, _StubStore]]:
-    plaintext = "cqa_exampletoken"
-    digest = hash_token(plaintext, pepper=PEPPER)
-    store = _StubStore({digest: _row()})
-    yield plaintext, store
+def token_and_store() -> Iterator[tuple[str, _StubStore, uuid.UUID]]:
+    key_id = uuid.uuid4()
+    secret = generate_secret()
+    token = encode_token(key_id=key_id, secret=secret)
+    store = _StubStore({key_id.hex: _row(key_id=key_id, secret=secret)})
+    yield token, store, key_id
 
 
 class TestRequireApiKeyHappyPath:
-    def test_valid_key_returns_username(self, token_and_store: tuple[str, _StubStore]) -> None:
-        token, store = token_and_store
+    def test_valid_key_returns_username(self, token_and_store: tuple[str, _StubStore, uuid.UUID]) -> None:
+        token, store, _ = token_and_store
         client = TestClient(_app_with_store(store))
         resp = client.get("/protected", headers={"Authorization": f"Bearer {token}"})
         assert resp.status_code == 200
         assert resp.json() == {"username": "alice"}
 
-    def test_valid_key_schedules_touch(self, token_and_store: tuple[str, _StubStore]) -> None:
-        token, store = token_and_store
+    def test_valid_key_schedules_touch(self, token_and_store: tuple[str, _StubStore, uuid.UUID]) -> None:
+        token, store, key_id = token_and_store
         client = TestClient(_app_with_store(store))
         client.get("/protected", headers={"Authorization": f"Bearer {token}"})
-        assert store.touched == ["k1"]
+        assert store.touched == [key_id.hex]
 
 
 class TestRequireApiKeyRejections:
@@ -98,34 +107,53 @@ class TestRequireApiKeyRejections:
         resp = client.get("/protected", headers={"Authorization": "Basic abc"})
         assert resp.status_code == 401
 
-    def test_wrong_prefix(self) -> None:
+    def test_wrong_namespace(self) -> None:
         client = TestClient(_app_with_store(_StubStore()))
-        resp = client.get("/protected", headers={"Authorization": "Bearer sk-something"})
+        token = f"sk.v1.{uuid.uuid4().hex}.sekret"
+        resp = client.get("/protected", headers={"Authorization": f"Bearer {token}"})
         assert resp.status_code == 401
 
-    def test_unknown_token(self) -> None:
+    def test_malformed_token(self) -> None:
         client = TestClient(_app_with_store(_StubStore()))
-        resp = client.get("/protected", headers={"Authorization": "Bearer cqa_unknown"})
+        resp = client.get("/protected", headers={"Authorization": "Bearer cqa_legacy"})
+        assert resp.status_code == 401
+
+    def test_unknown_key_id(self) -> None:
+        client = TestClient(_app_with_store(_StubStore()))
+        token = encode_token(key_id=uuid.uuid4(), secret=generate_secret())
+        resp = client.get("/protected", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 401
+
+    def test_wrong_secret(self) -> None:
+        key_id = uuid.uuid4()
+        stored_secret = generate_secret()
+        store = _StubStore({key_id.hex: _row(key_id=key_id, secret=stored_secret)})
+        presented_token = encode_token(key_id=key_id, secret=generate_secret())
+        client = TestClient(_app_with_store(store))
+        resp = client.get("/protected", headers={"Authorization": f"Bearer {presented_token}"})
         assert resp.status_code == 401
 
     def test_revoked_token(self) -> None:
-        token = "cqa_revokedtoken"
-        digest = hash_token(token, pepper=PEPPER)
-        store = _StubStore({digest: _row(revoked_at=datetime.now(UTC))})
+        key_id = uuid.uuid4()
+        secret = generate_secret()
+        store = _StubStore({key_id.hex: _row(key_id=key_id, secret=secret, revoked_at=datetime.now(UTC))})
+        token = encode_token(key_id=key_id, secret=secret)
         client = TestClient(_app_with_store(store))
         resp = client.get("/protected", headers={"Authorization": f"Bearer {token}"})
         assert resp.status_code == 401
 
     def test_expired_token(self) -> None:
-        token = "cqa_expiredtoken"
-        digest = hash_token(token, pepper=PEPPER)
-        store = _StubStore({digest: _row(expires_at=datetime.now(UTC) - timedelta(seconds=1))})
+        key_id = uuid.uuid4()
+        secret = generate_secret()
+        row = _row(key_id=key_id, secret=secret, expires_at=datetime.now(UTC) - timedelta(seconds=1))
+        store = _StubStore({key_id.hex: row})
+        token = encode_token(key_id=key_id, secret=secret)
         client = TestClient(_app_with_store(store))
         resp = client.get("/protected", headers={"Authorization": f"Bearer {token}"})
         assert resp.status_code == 401
 
-    def test_missing_pepper_returns_500(self, token_and_store: tuple[str, _StubStore]) -> None:
-        token, store = token_and_store
+    def test_missing_pepper_returns_500(self, token_and_store: tuple[str, _StubStore, uuid.UUID]) -> None:
+        token, store, _ = token_and_store
         client = TestClient(_app_with_store(store, pepper=None))
         resp = client.get("/protected", headers={"Authorization": f"Bearer {token}"})
         assert resp.status_code == 500

--- a/server/backend/tests/test_store.py
+++ b/server/backend/tests/test_store.py
@@ -516,14 +516,14 @@ class TestApiKeys:
     def _past(days: int = 1) -> str:
         return (datetime.now(UTC) - timedelta(days=days)).isoformat()
 
-    def test_create_and_fetch_by_hash(self, store: RemoteStore) -> None:
+    def test_create_and_fetch_active_by_id(self, store: RemoteStore) -> None:
         user_id = self._seed_user(store)
         row = store.create_api_key(
             key_id="k1",
             user_id=user_id,
             name="laptop",
             labels=[],
-            key_prefix="cqa_abcd",
+            key_prefix="abcdefgh",
             key_hash="hash-1",
             ttl="30d",
             expires_at=self._future(),
@@ -531,15 +531,31 @@ class TestApiKeys:
         assert row["id"] == "k1"
         assert row["revoked_at"] is None
 
-        fetched = store.get_api_key_by_hash("hash-1")
+        fetched = store.get_active_api_key_by_id("k1")
         assert fetched is not None
         assert fetched["id"] == "k1"
         assert fetched["username"] == "alice"
         assert fetched["user_id"] == user_id
         assert fetched["name"] == "laptop"
+        assert fetched["key_hash"] == "hash-1"
 
-    def test_get_by_hash_missing(self, store: RemoteStore) -> None:
-        assert store.get_api_key_by_hash("nope") is None
+    def test_get_active_by_id_missing(self, store: RemoteStore) -> None:
+        assert store.get_active_api_key_by_id("nope") is None
+
+    def test_get_active_by_id_excludes_revoked(self, store: RemoteStore) -> None:
+        user_id = self._seed_user(store)
+        store.create_api_key(
+            key_id="k1",
+            user_id=user_id,
+            name="laptop",
+            labels=[],
+            key_prefix="abcdefgh",
+            key_hash="hash-1",
+            ttl="30d",
+            expires_at=self._future(),
+        )
+        assert store.revoke_api_key(user_id=user_id, key_id="k1") is True
+        assert store.get_active_api_key_by_id("k1") is None
 
     def test_create_rejects_duplicate_hash(self, store: RemoteStore) -> None:
         user_id = self._seed_user(store)
@@ -686,9 +702,9 @@ class TestApiKeys:
             ttl="30d",
             expires_at=self._future(),
         )
-        assert store.get_api_key_by_hash("h")["last_used_at"] is None
+        assert store.get_active_api_key_by_id("k")["last_used_at"] is None
         store.touch_api_key_last_used("k")
-        assert store.get_api_key_by_hash("h")["last_used_at"] is not None
+        assert store.get_active_api_key_by_id("k")["last_used_at"] is not None
 
     def test_touch_last_used_missing_key_swallowed(self, store: RemoteStore) -> None:
         store.touch_api_key_last_used("nonexistent")  # No raise.

--- a/server/frontend/src/api.ts
+++ b/server/frontend/src/api.ts
@@ -1,6 +1,7 @@
 import type {
   ApiKeyPublic,
   CreatedApiKey,
+  MessageResponse,
   ReviewItem,
   ReviewQueueResponse,
   ReviewDecisionResponse,
@@ -121,7 +122,7 @@ export const api = {
     }),
 
   revokeApiKey: (id: string) =>
-    request<void>(`/auth/api-keys/${id}`, { method: "DELETE" }),
+    request<MessageResponse>(`/auth/api-keys/${id}/revoke`, { method: "POST" }),
 };
 
 export { ApiError };

--- a/server/frontend/src/api.ts
+++ b/server/frontend/src/api.ts
@@ -1,5 +1,5 @@
 import type {
-  ApiKeyPublic,
+  ApiKeysList,
   CreatedApiKey,
   MessageResponse,
   ReviewItem,
@@ -113,7 +113,7 @@ export const api = {
     return request<ReviewItem[]>(`/review/units${query ? `?${query}` : ""}`);
   },
 
-  listApiKeys: () => request<ApiKeyPublic[]>("/auth/api-keys"),
+  listApiKeys: () => request<ApiKeysList>("/auth/api-keys"),
 
   createApiKey: (name: string, ttl: string, labels: string[] = []) =>
     request<CreatedApiKey>("/auth/api-keys", {

--- a/server/frontend/src/pages/ApiKeysPage.test.tsx
+++ b/server/frontend/src/pages/ApiKeysPage.test.tsx
@@ -42,50 +42,36 @@ describe("ApiKeysPage", () => {
   });
 
   it("renders the empty state when no keys exist", async () => {
-    queueResponses([{ ok: true, status: 200, body: [] }]);
+    queueResponses([{ ok: true, status: 200, body: { data: [], count: 0 } }]);
     render(<ApiKeysPage />);
     expect(await screen.findByText(/no api keys yet/i)).toBeInTheDocument();
   });
 
   it("creates a key and shows the plaintext modal once", async () => {
+    const listedKey = {
+      id: "id1",
+      name: "laptop",
+      labels: [],
+      prefix: "cqa_abcd",
+      ttl: "90d",
+      expires_at: "2027-01-01T00:00:00+00:00",
+      created_at: "2026-04-16T00:00:00+00:00",
+      last_used_at: null,
+      revoked_at: null,
+      is_expired: false,
+      is_active: true,
+    }
     queueResponses([
-      { ok: true, status: 200, body: [] },
+      { ok: true, status: 200, body: { data: [], count: 0 } },
       {
         ok: true,
         status: 201,
-        body: {
-          id: "id1",
-          name: "laptop",
-          labels: [],
-          prefix: "cqa_abcd",
-          ttl: "90d",
-          token: "cqa_newplaintext",
-          expires_at: "2027-01-01T00:00:00+00:00",
-          created_at: "2026-04-16T00:00:00+00:00",
-          last_used_at: null,
-          revoked_at: null,
-          is_expired: false,
-          is_active: true,
-        },
+        body: { ...listedKey, token: "cqa_newplaintext" },
       },
       {
         ok: true,
         status: 200,
-        body: [
-          {
-            id: "id1",
-            name: "laptop",
-            labels: [],
-            prefix: "cqa_abcd",
-            ttl: "90d",
-            expires_at: "2027-01-01T00:00:00+00:00",
-            created_at: "2026-04-16T00:00:00+00:00",
-            last_used_at: null,
-            revoked_at: null,
-            is_expired: false,
-            is_active: true,
-          },
-        ],
+        body: { data: [listedKey], count: 1 },
       },
     ]);
 
@@ -109,46 +95,28 @@ describe("ApiKeysPage", () => {
   });
 
   it("revokes a key after confirmation", async () => {
+    const activeKey = {
+      id: "id1",
+      name: "laptop",
+      labels: [],
+      prefix: "cqa_abcd",
+      ttl: "90d",
+      expires_at: "2027-01-01T00:00:00+00:00",
+      created_at: "2026-04-16T00:00:00+00:00",
+      last_used_at: null,
+      revoked_at: null,
+      is_expired: false,
+      is_active: true,
+    }
+    const revokedKey = {
+      ...activeKey,
+      revoked_at: "2026-04-17T00:00:00+00:00",
+      is_active: false,
+    }
     queueResponses([
-      {
-        ok: true,
-        status: 200,
-        body: [
-          {
-            id: "id1",
-            name: "laptop",
-            labels: [],
-            prefix: "cqa_abcd",
-            ttl: "90d",
-            expires_at: "2027-01-01T00:00:00+00:00",
-            created_at: "2026-04-16T00:00:00+00:00",
-            last_used_at: null,
-            revoked_at: null,
-            is_expired: false,
-            is_active: true,
-          },
-        ],
-      },
+      { ok: true, status: 200, body: { data: [activeKey], count: 1 } },
       { ok: true, status: 200, body: { message: "API key revoked." } },
-      {
-        ok: true,
-        status: 200,
-        body: [
-          {
-            id: "id1",
-            name: "laptop",
-            labels: [],
-            prefix: "cqa_abcd",
-            ttl: "90d",
-            expires_at: "2027-01-01T00:00:00+00:00",
-            created_at: "2026-04-16T00:00:00+00:00",
-            last_used_at: null,
-            revoked_at: "2026-04-17T00:00:00+00:00",
-            is_expired: false,
-            is_active: false,
-          },
-        ],
-      },
+      { ok: true, status: 200, body: { data: [revokedKey], count: 1 } },
     ]);
 
     render(<ApiKeysPage />);

--- a/server/frontend/src/pages/ApiKeysPage.test.tsx
+++ b/server/frontend/src/pages/ApiKeysPage.test.tsx
@@ -129,7 +129,7 @@ describe("ApiKeysPage", () => {
           },
         ],
       },
-      { ok: true, status: 204, body: null },
+      { ok: true, status: 200, body: { message: "API key revoked." } },
       {
         ok: true,
         status: 200,

--- a/server/frontend/src/pages/ApiKeysPage.tsx
+++ b/server/frontend/src/pages/ApiKeysPage.tsx
@@ -121,8 +121,8 @@ export function ApiKeysPage() {
   const refresh = useCallback(async () => {
     setLoading(true);
     try {
-      const data = await api.listApiKeys();
-      setKeys(data);
+      const response = await api.listApiKeys();
+      setKeys(response.data);
       setError(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load API keys");

--- a/server/frontend/src/types.ts
+++ b/server/frontend/src/types.ts
@@ -101,6 +101,11 @@ export interface CreatedApiKey extends ApiKeyPublic {
   token: string;
 }
 
+export interface ApiKeysList {
+  data: ApiKeyPublic[]
+  count: number
+}
+
 export interface MessageResponse {
   message: string
 }

--- a/server/frontend/src/types.ts
+++ b/server/frontend/src/types.ts
@@ -100,3 +100,7 @@ export interface ApiKeyPublic {
 export interface CreatedApiKey extends ApiKeyPublic {
   token: string;
 }
+
+export interface MessageResponse {
+  message: string
+}

--- a/server/frontend/src/types.ts
+++ b/server/frontend/src/types.ts
@@ -102,10 +102,10 @@ export interface CreatedApiKey extends ApiKeyPublic {
 }
 
 export interface ApiKeysList {
-  data: ApiKeyPublic[]
-  count: number
+  data: ApiKeyPublic[];
+  count: number;
 }
 
 export interface MessageResponse {
-  message: string
+  message: string;
 }

--- a/server/scripts/seed-kus.py
+++ b/server/scripts/seed-kus.py
@@ -87,7 +87,7 @@ def _create_api_key(base_url: str, jwt_token: str) -> tuple[str, str]:
 def _revoke_api_key(base_url: str, jwt_token: str, key_id: str) -> None:
     """Revoke the seed API key. Failures are logged and swallowed."""
     try:
-        _request(f"{base_url}/auth/api-keys/{key_id}", method="DELETE", token=jwt_token)
+        _request(f"{base_url}/auth/api-keys/{key_id}/revoke", method="POST", token=jwt_token)
     except SystemExit as exc:
         print(f"  warning: failed to revoke seed API key {key_id}: {exc}")
 


### PR DESCRIPTION
## Summary

Three independent refactors to the API key surface:

1. **Versioned token format** (`cqa.v1.<uuid>.<secret>`) with
   lookup-by-id and constant-time HMAC comparison on the secret.
2. **Revoke as a state transition** via
   `POST /auth/api-keys/{id}/revoke` returning `Message`,
   replacing `DELETE ... -> 204`.
3. **List envelope**: `GET /auth/api-keys` now returns
   `{ data, count }` instead of a bare array, leaving room
   for pagination metadata without a future breaking change.

## Test plan

- [ ] `make lint`
- [ ] `make test` (backend 199, frontend 11, SDK/Go/schema)
- [ ] Manual: create a key via the UI, copy the plaintext,
      authenticate an SDK call with it, revoke via the UI,
      and confirm a 401 on the next SDK call.