### PR TITLE
server: baseline Alembic migration + stamp-on-startup logic

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -35,6 +35,13 @@ COPY backend/pyproject.toml backend/uv.lock ./
 RUN uv sync --no-dev --frozen --no-install-project
 
 COPY backend/src/ src/
+# Alembic config + migration scripts must ship in the image; the
+# startup migration runner (`cq_server.migrations`) walks parents
+# of its own __file__ looking for `alembic.ini` and the `versions/`
+# directory referenced by it. Without these, importing the module
+# raises at container start.
+COPY backend/alembic.ini ./alembic.ini
+COPY backend/alembic/ alembic/
 RUN uv sync --no-dev --frozen
 
 # Copy the frontend build output into the package's static directory.

--- a/server/backend/README.md
+++ b/server/backend/README.md
@@ -15,21 +15,40 @@ make lint-server-backend    # pre-commit (ruff, ty, uv lock check)
 
 ## Database migrations (Alembic)
 
-SQLAlchemy and Alembic are wired up but **currently unused at
-runtime** — no migrations are defined, and `app.py` still creates
-the SQLite schema directly. This is intentional; the framework is
-staged so follow-up work in the [PostgreSQL-backend epic][epic] can
-land the baseline migration, the async `Store` protocol, and the
-Postgres backend incrementally.
+The server runs Alembic migrations on every start, before opening the
+store. The runner (`cq_server.migrations.run_migrations`) handles
+three cases:
 
-Database URL resolution (used by `alembic/env.py` and, in a later
-child issue, the runtime store factory) lives in
-`cq_server.db_url.resolve_database_url`. Precedence:
+1. **New database** (no tables) — applies the baseline migration,
+   creating every table from scratch. The `alembic_version` row is
+   written as part of that.
+2. **Existing pre-Alembic database** (data tables present, no
+   `alembic_version`) — *stamps* the baseline revision without
+   re-running its DDL, then runs any later migrations. This is the
+   first-restart-after-upgrade case for a server that's been running
+   on the legacy `_ensure_schema()` path. **No DDL re-runs, no data
+   touched, no downtime** — the change is a single insert into a new
+   table.
+3. **Already-managed database** — `upgrade head` is a no-op when
+   there are no pending revisions, so restart is idempotent.
+
+Database URL resolution (used by `alembic/env.py`, the migration
+runner, and — in a later child issue — the runtime store factory)
+lives in `cq_server.db_url.resolve_database_url`. Precedence:
 
 1. `CQ_DATABASE_URL` — used verbatim (e.g. `postgresql+psycopg://…`).
 2. `CQ_DB_PATH` — wrapped as `sqlite:///<path>` (back-compat with
    the existing env var).
 3. Default — `sqlite:////data/cq.db`.
+
+The `RemoteStore` constructor still calls the legacy
+`_ensure_schema()` for safety during the rollout window. Both the
+migration and the legacy DDL are idempotent, so running them in
+sequence is harmless. The legacy path will be removed in
+[issue #310][issue-310] once this PR has deployed everywhere — until
+then, any schema change must be added as a new Alembic migration
+*and* mirrored in `cq_server/tables.py` / `cq_server/store/__init__.py`
+to keep the two paths in sync.
 
 To run Alembic commands against a local dev database (the path is
 resolved relative to wherever `alembic` is invoked from — here,
@@ -37,10 +56,11 @@ resolved relative to wherever `alembic` is invoked from — here,
 
 ```
 cd server/backend
-CQ_DB_PATH=./dev.db uv run alembic current
+CQ_DB_PATH=./dev.db uv run alembic current   # show current revision
+CQ_DB_PATH=./dev.db uv run alembic upgrade head
 ```
 
 Full environment-variable documentation will land alongside the
 `CQ_DATABASE_URL` runtime wiring in a later phase-1 child issue.
 
-[epic]: https://github.com/mozilla-ai/cq/issues/257
+[epic](https://github.com/mozilla-ai/cq/issues/257)

--- a/server/backend/README.md
+++ b/server/backend/README.md
@@ -63,4 +63,4 @@ CQ_DB_PATH=./dev.db uv run alembic upgrade head
 Full environment-variable documentation will land alongside the
 `CQ_DATABASE_URL` runtime wiring in a later phase-1 child issue.
 
-[epic](https://github.com/mozilla-ai/cq/issues/257)
+[issue-310]: https://github.com/mozilla-ai/cq/issues/310

--- a/server/backend/README.md
+++ b/server/backend/README.md
@@ -36,7 +36,10 @@ Database URL resolution (used by `alembic/env.py`, the migration
 runner, and — in a later child issue — the runtime store factory)
 lives in `cq_server.db_url.resolve_database_url`. Precedence:
 
-1. `CQ_DATABASE_URL` — used verbatim (e.g. `postgresql+psycopg://…`).
+1. `CQ_DATABASE_URL` — used verbatim. **Today this must be a SQLite
+   URL** (e.g. `sqlite:////data/cq.db`); the runtime store is still
+   SQLite-only and the server rejects non-SQLite URLs at startup.
+   Postgres support lands with #309/#311.
 2. `CQ_DB_PATH` — wrapped as `sqlite:///<path>` (back-compat with
    the existing env var).
 3. Default — `sqlite:////data/cq.db`.

--- a/server/backend/alembic/env.py
+++ b/server/backend/alembic/env.py
@@ -2,15 +2,20 @@
 
 The database URL is resolved from the environment via
 :func:`cq_server.db_url.resolve_database_url` so that ``alembic``
-CLI invocations and future startup-time ``command.upgrade`` calls
-share the same precedence rules.
+CLI invocations and startup-time ``command.upgrade`` calls share
+the same precedence rules. Programmatic callers (notably
+``cq_server.migrations.run_migrations``) may pin a URL on the
+Config before invoking Alembic; in that case the pre-set value
+wins so tests can target tmp_path-rooted SQLite files without
+mutating the process environment.
 
 ``render_as_batch=True`` is set in both online and offline modes so
 SQLite ALTER TABLE operations work via Alembic's batch recreate
 dance. It is harmless on PostgreSQL.
 
-No migrations exist yet — ``target_metadata`` is ``None``. The
-baseline migration lands in issue #305.
+The baseline migration (revision ``0001``) was added in #305. The
+runner stamps existing pre-Alembic databases at this revision; new
+databases get the migration run normally.
 """
 
 from __future__ import annotations
@@ -31,7 +36,8 @@ if config.config_file_name is not None:
 # start of an interpolation token. Fine for SQLite paths today, but a
 # Postgres URL with a URL-encoded password (e.g. `p%40ss`) will need
 # `%` doubled or a direct pass to `create_engine` when #309 wires this up.
-config.set_main_option("sqlalchemy.url", resolve_database_url())
+if not config.get_main_option("sqlalchemy.url"):
+    config.set_main_option("sqlalchemy.url", resolve_database_url())
 
 target_metadata = None
 

--- a/server/backend/alembic/env.py
+++ b/server/backend/alembic/env.py
@@ -1,13 +1,16 @@
 """Alembic runtime configuration for the cq server.
 
-The database URL is resolved from the environment via
-:func:`cq_server.db_url.resolve_database_url` so that ``alembic``
-CLI invocations and startup-time ``command.upgrade`` calls share
-the same precedence rules. Programmatic callers (notably
-``cq_server.migrations.run_migrations``) may pin a URL on the
-Config before invoking Alembic; in that case the pre-set value
-wins so tests can target tmp_path-rooted SQLite files without
-mutating the process environment.
+Both entry points — startup (``cq_server.migrations.run_migrations``)
+and the ``alembic`` CLI — must avoid round-tripping the database URL
+through ConfigParser. ``Config.set_main_option`` runs interpolation
+eagerly and raises on any literal ``%`` (URL-encoded passwords,
+SQLite filenames with ``%``, etc.).
+
+The runtime path hands a live connection in via
+``config.attributes["connection"]`` and we use it directly. The CLI
+path resolves the URL at use-time via
+:func:`cq_server.db_url.resolve_database_url` and builds its own
+engine — never going through ``set_main_option``.
 
 ``render_as_batch=True`` is set in both online and offline modes so
 SQLite ALTER TABLE operations work via Alembic's batch recreate
@@ -23,7 +26,7 @@ from __future__ import annotations
 from logging.config import fileConfig
 
 from alembic import context
-from sqlalchemy import engine_from_config, pool
+from sqlalchemy import create_engine, pool
 
 from cq_server.db_url import resolve_database_url
 
@@ -32,20 +35,27 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-# `set_main_option` routes through ConfigParser, which treats `%` as the
-# start of an interpolation token. Fine for SQLite paths today, but a
-# Postgres URL with a URL-encoded password (e.g. `p%40ss`) will need
-# `%` doubled or a direct pass to `create_engine` when #309 wires this up.
-if not config.get_main_option("sqlalchemy.url"):
-    config.set_main_option("sqlalchemy.url", resolve_database_url())
-
 target_metadata = None
+
+
+def _resolve_url() -> str:
+    """Return the database URL without going through ConfigParser.
+
+    A URL pinned on the Config (via ``set_main_option``) would win, but
+    no caller does that any more — the runtime hands a connection in
+    via ``cfg.attributes["connection"]``. Falling back to env-var
+    resolution covers the CLI path (``alembic upgrade head``).
+    """
+    pinned = config.get_main_option("sqlalchemy.url")
+    if pinned:
+        return pinned
+    return resolve_database_url()
 
 
 def run_migrations_offline() -> None:
     """Run migrations in 'offline' mode — emit SQL without a connection."""
     context.configure(
-        url=config.get_main_option("sqlalchemy.url"),
+        url=_resolve_url(),
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
@@ -57,22 +67,42 @@ def run_migrations_offline() -> None:
 
 
 def run_migrations_online() -> None:
-    """Run migrations in 'online' mode — against a live connection."""
-    connectable = engine_from_config(
-        config.get_section(config.config_ini_section, {}),
-        prefix="sqlalchemy.",
-        poolclass=pool.NullPool,
-    )
+    """Run migrations in 'online' mode — against a live connection.
 
-    with connectable.connect() as connection:
+    Two cases:
+
+    * The runtime caller (``cq_server.migrations.run_migrations``)
+      attaches an already-open connection to
+      ``config.attributes["connection"]``. Use it directly so the URL
+      never touches ConfigParser.
+    * The CLI path (``alembic upgrade head``) supplies no connection;
+      build the engine programmatically from ``_resolve_url`` rather
+      than via ``engine_from_config``, which would re-introduce the
+      ConfigParser interpolation hazard for any ``%`` in the URL.
+    """
+    connection = config.attributes.get("connection")
+    if connection is not None:
         context.configure(
             connection=connection,
             target_metadata=target_metadata,
             render_as_batch=True,
         )
-
         with context.begin_transaction():
             context.run_migrations()
+        return
+
+    engine = create_engine(_resolve_url(), poolclass=pool.NullPool)
+    try:
+        with engine.connect() as conn:
+            context.configure(
+                connection=conn,
+                target_metadata=target_metadata,
+                render_as_batch=True,
+            )
+            with context.begin_transaction():
+                context.run_migrations()
+    finally:
+        engine.dispose()
 
 
 if context.is_offline_mode():

--- a/server/backend/alembic/versions/0001_baseline.py
+++ b/server/backend/alembic/versions/0001_baseline.py
@@ -1,0 +1,112 @@
+"""Baseline schema.
+
+Revision ID: 0001
+Revises:
+Create Date: 2026-04-25
+
+Reverse-engineered from the current production SQLite schema — i.e.
+the union of:
+
+  - ``cq_server.store._SCHEMA_SQL`` (knowledge_units, knowledge_unit_domains,
+    idx_domains_domain).
+  - ``cq_server.tables._REVIEW_COLUMN_STATEMENTS`` (the trailing ALTER
+    TABLE … ADD COLUMN suite that grew the review/tier columns).
+  - ``cq_server.tables.USERS_TABLE_SQL`` and ``API_KEYS_TABLE_SQL``.
+
+Existing pre-Alembic databases are stamped at this revision in
+``cq_server.migrations.run_migrations`` rather than upgraded into it,
+so the column order and constraints below must match what's already
+on disk in production. **Do not edit this migration after merge** —
+production DBs will be stamped at this revision and any change here
+will diverge from what's actually on disk. Add a new migration file
+instead.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0001"
+down_revision: str | Sequence[str] | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the production schema from scratch."""
+    # Order: id, data, then the historical ALTER-added columns in the
+    # exact order they were added on prod
+    # (status, reviewed_by, reviewed_at, created_at, tier).
+    op.create_table(
+        "knowledge_units",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("data", sa.Text(), nullable=False),
+        sa.Column(
+            "status",
+            sa.Text(),
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column("reviewed_by", sa.Text(), nullable=True),
+        sa.Column("reviewed_at", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.Text(), nullable=True),
+        sa.Column(
+            "tier",
+            sa.Text(),
+            nullable=False,
+            server_default="private",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "knowledge_unit_domains",
+        sa.Column("unit_id", sa.Text(), nullable=False),
+        sa.Column("domain", sa.Text(), nullable=False),
+        sa.ForeignKeyConstraint(["unit_id"], ["knowledge_units.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("unit_id", "domain"),
+    )
+    op.create_index("idx_domains_domain", "knowledge_unit_domains", ["domain"])
+
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("username", sa.Text(), nullable=False),
+        sa.Column("password_hash", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.Text(), nullable=False),
+        sa.UniqueConstraint("username"),
+        # SQLite-specific: emit the AUTOINCREMENT keyword so the rowid
+        # monotonicity guarantee matches the legacy schema. No-op on
+        # PostgreSQL (uses SERIAL/IDENTITY automatically).
+        sqlite_autoincrement=True,
+    )
+
+    op.create_table(
+        "api_keys",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("labels", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("key_prefix", sa.Text(), nullable=False),
+        sa.Column("key_hash", sa.Text(), nullable=False),
+        sa.Column("ttl", sa.Text(), nullable=False),
+        sa.Column("expires_at", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.Text(), nullable=False),
+        sa.Column("last_used_at", sa.Text(), nullable=True),
+        sa.Column("revoked_at", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("key_hash"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+    )
+    op.create_index("idx_api_keys_user", "api_keys", ["user_id"])
+
+
+def downgrade() -> None:
+    """Drop everything the upgrade created. Never used in production."""
+    op.drop_index("idx_api_keys_user", table_name="api_keys")
+    op.drop_table("api_keys")
+    op.drop_table("users")
+    op.drop_index("idx_domains_domain", table_name="knowledge_unit_domains")
+    op.drop_table("knowledge_unit_domains")
+    op.drop_table("knowledge_units")

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -22,6 +22,7 @@ from starlette.responses import FileResponse
 
 from .auth import router as auth_router
 from .deps import API_KEY_PEPPER_ENV, require_api_key
+from .migrations import run_migrations
 from .review import router as review_router
 from .scoring import apply_confirmation, apply_flag
 from .store import RemoteStore, normalize_domains
@@ -73,6 +74,16 @@ async def lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
     if not pepper:
         raise RuntimeError(f"{API_KEY_PEPPER_ENV} environment variable is required")
     db_path = Path(os.environ.get("CQ_DB_PATH", "/data/cq.db"))
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    # Bring the database under Alembic management before opening the
+    # store. Three cases handled inside run_migrations: fresh DB →
+    # upgrade head; pre-Alembic DB → stamp baseline + upgrade head;
+    # already-stamped DB → upgrade head (no-op when no pending
+    # revisions). The legacy ``_ensure_schema()`` inside RemoteStore
+    # still runs after this; both paths are idempotent and the legacy
+    # one will be removed in #310 once this PR has rolled out
+    # everywhere.
+    run_migrations(f"sqlite:///{db_path}")
     _store = RemoteStore(db_path=db_path)
     app_instance.state.store = _store
     app_instance.state.api_key_pepper = pepper

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -74,16 +74,16 @@ async def lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
     if not pepper:
         raise RuntimeError(f"{API_KEY_PEPPER_ENV} environment variable is required")
     db_path = Path(os.environ.get("CQ_DB_PATH", "/data/cq.db"))
-    db_path.parent.mkdir(parents=True, exist_ok=True)
     # Bring the database under Alembic management before opening the
-    # store. Three cases handled inside run_migrations: fresh DB →
-    # upgrade head; pre-Alembic DB → stamp baseline + upgrade head;
-    # already-stamped DB → upgrade head (no-op when no pending
-    # revisions). The legacy ``_ensure_schema()`` inside RemoteStore
-    # still runs after this; both paths are idempotent and the legacy
-    # one will be removed in #310 once this PR has rolled out
-    # everywhere.
-    run_migrations(f"sqlite:///{db_path}")
+    # store. ``run_migrations`` resolves the URL itself (honouring
+    # ``CQ_DATABASE_URL`` precedence per ``resolve_database_url``) and
+    # mkdir's the SQLite parent. Three cases handled: fresh DB → upgrade
+    # head; pre-Alembic DB → stamp baseline + upgrade head; already-
+    # stamped DB → upgrade head (no-op when no pending revisions). The
+    # legacy ``_ensure_schema()`` inside RemoteStore still runs after
+    # this; both paths are idempotent and the legacy one will be
+    # removed in #310 once this PR has rolled out everywhere.
+    run_migrations()
     _store = RemoteStore(db_path=db_path)
     app_instance.state.store = _store
     app_instance.state.api_key_pepper = pepper

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -21,6 +21,7 @@ from pydantic import BaseModel, Field
 from starlette.responses import FileResponse
 
 from .auth import router as auth_router
+from .db_url import resolve_sqlite_db_path
 from .deps import API_KEY_PEPPER_ENV, require_api_key
 from .migrations import run_migrations
 from .review import router as review_router
@@ -73,17 +74,19 @@ async def lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
     pepper = os.environ.get(API_KEY_PEPPER_ENV, "")
     if not pepper:
         raise RuntimeError(f"{API_KEY_PEPPER_ENV} environment variable is required")
-    db_path = Path(os.environ.get("CQ_DB_PATH", "/data/cq.db"))
+    # Resolve URL and filesystem path together so the migration runner
+    # and the runtime store cannot diverge on which database they're
+    # using — see ``resolve_sqlite_db_path``. This drops once #309
+    # wires ``RemoteStore`` to ``CQ_DATABASE_URL`` directly.
+    database_url, db_path = resolve_sqlite_db_path()
     # Bring the database under Alembic management before opening the
-    # store. ``run_migrations`` resolves the URL itself (honouring
-    # ``CQ_DATABASE_URL`` precedence per ``resolve_database_url``) and
-    # mkdir's the SQLite parent. Three cases handled: fresh DB → upgrade
-    # head; pre-Alembic DB → stamp baseline + upgrade head; already-
-    # stamped DB → upgrade head (no-op when no pending revisions). The
-    # legacy ``_ensure_schema()`` inside RemoteStore still runs after
-    # this; both paths are idempotent and the legacy one will be
-    # removed in #310 once this PR has rolled out everywhere.
-    run_migrations()
+    # store. Three cases handled: fresh DB → upgrade head; pre-Alembic
+    # DB → stamp baseline + upgrade head; already-stamped DB → upgrade
+    # head (no-op when no pending revisions). The legacy
+    # ``_ensure_schema()`` inside RemoteStore still runs after this;
+    # both paths are idempotent and the legacy one will be removed in
+    # #310 once this PR has rolled out everywhere.
+    run_migrations(database_url)
     _store = RemoteStore(db_path=db_path)
     app_instance.state.store = _store
     app_instance.state.api_key_pepper = pepper

--- a/server/backend/src/cq_server/db_url.py
+++ b/server/backend/src/cq_server/db_url.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
+
+from sqlalchemy.engine import make_url
 
 _DEFAULT_SQLITE_PATH = "/data/cq.db"
 
@@ -20,3 +23,27 @@ def resolve_database_url() -> str:
         return url
     path = os.environ.get("CQ_DB_PATH", _DEFAULT_SQLITE_PATH)
     return f"sqlite:///{path}"
+
+
+def resolve_sqlite_db_path() -> tuple[str, Path]:
+    """Return ``(url, path)`` for the cq SQLite database.
+
+    Used by the FastAPI lifespan to drive both the migration runner and
+    the ``RemoteStore`` from the same source — without this, setting
+    ``CQ_DATABASE_URL`` would migrate one database while the runtime
+    store opened another. Until the Postgres store lands (#309/#311)
+    the runtime is SQLite-only, so a non-SQLite URL is rejected here
+    rather than silently misconfiguring the server.
+    """
+    url = resolve_database_url()
+    parsed = make_url(url)
+    if not parsed.drivername.startswith("sqlite"):
+        raise RuntimeError(
+            f"CQ_DATABASE_URL must be a SQLite URL until the Postgres store "
+            f"lands (#309/#311); got driver {parsed.drivername!r}."
+        )
+    if not parsed.database or parsed.database == ":memory:":
+        raise RuntimeError(
+            "CQ_DATABASE_URL must point at a SQLite file; in-memory and blank databases are not supported."
+        )
+    return url, Path(parsed.database)

--- a/server/backend/src/cq_server/migrations.py
+++ b/server/backend/src/cq_server/migrations.py
@@ -94,30 +94,41 @@ def run_migrations(database_url: str | None = None) -> None:
     redacted = _redact_url(url)
 
     cfg = Config(str(_ALEMBIC_INI))
-    # ConfigParser interpolation caveat: `%` in URLs (e.g. URL-encoded
-    # passwords) would need doubling here. Harmless for SQLite paths;
-    # #309/#311 will revisit when Postgres URLs land at runtime.
-    cfg.set_main_option("sqlalchemy.url", url)
 
+    # Hand Alembic a live connection via ``cfg.attributes`` rather than
+    # going through ``cfg.set_main_option("sqlalchemy.url", url)``. The
+    # latter routes through ConfigParser's interpolation engine, which
+    # raises ``ValueError: invalid interpolation syntax`` eagerly on any
+    # literal ``%`` in the URL — a foot-gun once URL-encoded passwords
+    # land with Postgres in #309/#311, and already triggerable today by
+    # a SQLite filename containing ``%``. ``env.py`` picks up the
+    # connection before it tries to build its own engine.
     engine = create_engine(url)
     try:
-        tables = set(inspect(engine).get_table_names())
+        # ``engine.begin()`` (not ``connect()``) so the alembic_version
+        # row written by stamp/upgrade actually commits at block exit —
+        # this matches the Alembic cookbook recipe for "sharing a
+        # connection with a series of migration commands."
+        with engine.begin() as connection:
+            tables = set(inspect(connection).get_table_names())
+            cfg.attributes["connection"] = connection
+
+            if "alembic_version" not in tables and "knowledge_units" in tables:
+                # Pre-Alembic prod DB: the schema already exists, just
+                # record that we're at baseline so ``upgrade head``
+                # doesn't re-run the CREATE TABLE statements (which
+                # would fail).
+                _logger.info(
+                    "Pre-Alembic database detected at %s; stamping at baseline %s",
+                    redacted,
+                    BASELINE_REVISION,
+                )
+                command.stamp(cfg, BASELINE_REVISION)
+
+            _logger.info("Running Alembic upgrade head against %s", redacted)
+            command.upgrade(cfg, "head")
     finally:
         engine.dispose()
-
-    if "alembic_version" not in tables and "knowledge_units" in tables:
-        # Pre-Alembic prod DB: the schema already exists, just record
-        # that we're at baseline so `upgrade head` doesn't re-run the
-        # CREATE TABLE statements (which would fail).
-        _logger.info(
-            "Pre-Alembic database detected at %s; stamping at baseline %s",
-            redacted,
-            BASELINE_REVISION,
-        )
-        command.stamp(cfg, BASELINE_REVISION)
-
-    _logger.info("Running Alembic upgrade head against %s", redacted)
-    command.upgrade(cfg, "head")
 
 
 def _redact_url(url: str) -> str:

--- a/server/backend/src/cq_server/migrations.py
+++ b/server/backend/src/cq_server/migrations.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from urllib.parse import urlparse
 
 from alembic import command
 from alembic.config import Config
@@ -65,13 +64,15 @@ def _ensure_sqlite_parent_dir(url: str) -> None:
     """
     if not url.startswith("sqlite:"):
         return
-    parsed = urlparse(url)
-    # `sqlite:///abs/path` → parsed.path == '/abs/path'
-    # `sqlite:///./rel.db` → parsed.path == '/./rel.db'
-    # `sqlite://` (in-memory)→ parsed.path == ''
-    if not parsed.path or parsed.path == "/:memory:":
+    # Use SQLAlchemy's URL parser rather than urlparse: it correctly
+    # round-trips both absolute (`sqlite:////abs/path`) and relative
+    # (`sqlite:///./rel.db`) SQLite URLs to a usable filesystem path,
+    # whereas `urlparse(...).path` prefixes a stray `/` that turns
+    # `./data/dev.db` into the absolute `/data/dev.db`.
+    database = make_url(url).database
+    if not database or database == ":memory:":
         return
-    Path(parsed.path).parent.mkdir(parents=True, exist_ok=True)
+    Path(database).parent.mkdir(parents=True, exist_ok=True)
 
 
 def run_migrations(database_url: str | None = None) -> None:

--- a/server/backend/src/cq_server/migrations.py
+++ b/server/backend/src/cq_server/migrations.py
@@ -1,0 +1,88 @@
+"""Run Alembic migrations at server startup.
+
+Three cases the runner has to handle, all covered by
+``run_migrations``:
+
+* New database (no tables) — ``upgrade head`` creates everything via
+  the baseline migration.
+* Existing pre-Alembic database (``knowledge_units`` exists,
+  ``alembic_version`` does not) — ``stamp`` at the baseline so Alembic
+  records "the current schema is what the baseline migration would
+  have produced", then ``upgrade head`` to apply any later migrations.
+* Already-stamped database — ``upgrade head`` is a no-op when there
+  are no pending migrations.
+
+The baseline revision id is exported so tests and ops scripts can
+reference it without parsing migration files.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from urllib.parse import urlparse
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect
+
+from .db_url import resolve_database_url
+
+__all__ = ["BASELINE_REVISION", "run_migrations"]
+
+BASELINE_REVISION = "0001"
+
+# alembic.ini lives at the package backend root: server/backend/alembic.ini.
+# This module is at server/backend/src/cq_server/migrations.py — three
+# parents up from __file__ gets us to server/backend/.
+_ALEMBIC_INI = Path(__file__).resolve().parents[2] / "alembic.ini"
+
+
+def _ensure_sqlite_parent_dir(url: str) -> None:
+    """Create the parent directory of a sqlite file URL if missing.
+
+    Until #309 wires the runtime store to ``CQ_DATABASE_URL``, the
+    server still mkdir's the SQLite parent inside ``RemoteStore``;
+    but the migration runs first now, so we hoist the directory
+    creation here. No-op for non-sqlite URLs.
+    """
+    if not url.startswith("sqlite:"):
+        return
+    parsed = urlparse(url)
+    # `sqlite:///abs/path` → parsed.path == '/abs/path'
+    # `sqlite:///./rel.db` → parsed.path == '/./rel.db'
+    # `sqlite://` (in-memory)→ parsed.path == ''
+    if not parsed.path or parsed.path == "/:memory:":
+        return
+    Path(parsed.path).parent.mkdir(parents=True, exist_ok=True)
+
+
+def run_migrations(database_url: str | None = None) -> None:
+    """Bring the configured database to head, stamping legacy DBs first.
+
+    Args:
+        database_url: SQLAlchemy URL to migrate. Defaults to the value
+            from :func:`cq_server.db_url.resolve_database_url`, which
+            consults ``CQ_DATABASE_URL`` and ``CQ_DB_PATH``.
+    """
+    url = database_url or resolve_database_url()
+    _ensure_sqlite_parent_dir(url)
+
+    cfg = Config(str(_ALEMBIC_INI))
+    # ConfigParser interpolation caveat: `%` in URLs (e.g. URL-encoded
+    # passwords) would need doubling here. Harmless for SQLite paths;
+    # #309/#311 will revisit when Postgres URLs land at runtime.
+    cfg.set_main_option("sqlalchemy.url", url)
+
+    engine = create_engine(url)
+    try:
+        tables = set(inspect(engine).get_table_names())
+    finally:
+        engine.dispose()
+
+    if "alembic_version" not in tables and "knowledge_units" in tables:
+        # Pre-Alembic prod DB: the schema already exists, just record
+        # that we're at baseline so `upgrade head` doesn't re-run the
+        # CREATE TABLE statements (which would fail).
+        command.stamp(cfg, BASELINE_REVISION)
+
+    command.upgrade(cfg, "head")

--- a/server/backend/src/cq_server/migrations.py
+++ b/server/backend/src/cq_server/migrations.py
@@ -18,23 +18,41 @@ reference it without parsing migration files.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from urllib.parse import urlparse
 
 from alembic import command
 from alembic.config import Config
 from sqlalchemy import create_engine, inspect
+from sqlalchemy.engine import make_url
 
 from .db_url import resolve_database_url
 
 __all__ = ["BASELINE_REVISION", "run_migrations"]
 
+_logger = logging.getLogger(__name__)
+
 BASELINE_REVISION = "0001"
 
-# alembic.ini lives at the package backend root: server/backend/alembic.ini.
-# This module is at server/backend/src/cq_server/migrations.py — three
-# parents up from __file__ gets us to server/backend/.
-_ALEMBIC_INI = Path(__file__).resolve().parents[2] / "alembic.ini"
+
+def _find_alembic_ini() -> Path:
+    """Locate ``alembic.ini`` by walking up from this module.
+
+    The file lives at ``server/backend/alembic.ini`` while this module
+    is at ``server/backend/src/cq_server/migrations.py``. Walking
+    parents (capped at 5 levels) tolerates layout shifts within the
+    package without finding an unrelated ``alembic.ini`` further up the
+    filesystem.
+    """
+    for parent in list(Path(__file__).resolve().parents)[:5]:
+        candidate = parent / "alembic.ini"
+        if candidate.exists():
+            return candidate
+    raise RuntimeError("alembic.ini not found near cq_server.migrations module")
+
+
+_ALEMBIC_INI = _find_alembic_ini()
 
 
 def _ensure_sqlite_parent_dir(url: str) -> None:
@@ -59,6 +77,12 @@ def _ensure_sqlite_parent_dir(url: str) -> None:
 def run_migrations(database_url: str | None = None) -> None:
     """Bring the configured database to head, stamping legacy DBs first.
 
+    Assumes a single caller per database — concurrent invocations across
+    replicas can race on the table-presence check and on ``upgrade``
+    itself. Safe for the current single-instance SQLite deployment;
+    #309/#311 will revisit (likely via ``pg_advisory_lock``) when
+    Postgres + multi-replica land.
+
     Args:
         database_url: SQLAlchemy URL to migrate. Defaults to the value
             from :func:`cq_server.db_url.resolve_database_url`, which
@@ -66,6 +90,7 @@ def run_migrations(database_url: str | None = None) -> None:
     """
     url = database_url or resolve_database_url()
     _ensure_sqlite_parent_dir(url)
+    redacted = _redact_url(url)
 
     cfg = Config(str(_ALEMBIC_INI))
     # ConfigParser interpolation caveat: `%` in URLs (e.g. URL-encoded
@@ -83,6 +108,20 @@ def run_migrations(database_url: str | None = None) -> None:
         # Pre-Alembic prod DB: the schema already exists, just record
         # that we're at baseline so `upgrade head` doesn't re-run the
         # CREATE TABLE statements (which would fail).
+        _logger.info(
+            "Pre-Alembic database detected at %s; stamping at baseline %s",
+            redacted,
+            BASELINE_REVISION,
+        )
         command.stamp(cfg, BASELINE_REVISION)
 
+    _logger.info("Running Alembic upgrade head against %s", redacted)
     command.upgrade(cfg, "head")
+
+
+def _redact_url(url: str) -> str:
+    """Return a log-safe rendering of the URL with the password masked."""
+    try:
+        return make_url(url).render_as_string(hide_password=True)
+    except Exception:  # noqa: BLE001 — never let logging break startup
+        return "<unparseable url>"

--- a/server/backend/tests/test_db_url.py
+++ b/server/backend/tests/test_db_url.py
@@ -1,6 +1,10 @@
 """Tests for resolve_database_url()."""
 
-from cq_server.db_url import resolve_database_url
+from pathlib import Path
+
+import pytest
+
+from cq_server.db_url import resolve_database_url, resolve_sqlite_db_path
 
 
 def test_explicit_database_url_wins(monkeypatch):
@@ -29,3 +33,49 @@ def test_empty_database_url_falls_through(monkeypatch, tmp_path):
     monkeypatch.setenv("CQ_DATABASE_URL", "")
     monkeypatch.setenv("CQ_DB_PATH", str(db))
     assert resolve_database_url() == f"sqlite:///{db}"
+
+
+class TestResolveSqliteDbPath:
+    """``resolve_sqlite_db_path`` is the single source of truth for both the
+    migration URL and the runtime store's filesystem path during the
+    rollout window. Any divergence here is a footgun: migrations would
+    target one DB while the server reads/writes another.
+    """
+
+    def test_returns_url_and_path_for_cq_db_path(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("CQ_DATABASE_URL", raising=False)
+        db = tmp_path / "cq.db"
+        monkeypatch.setenv("CQ_DB_PATH", str(db))
+
+        url, path = resolve_sqlite_db_path()
+
+        assert url == f"sqlite:///{db}"
+        assert path == db
+
+    def test_cq_database_url_governs_both_url_and_path(self, monkeypatch, tmp_path):
+        winning = tmp_path / "winning.db"
+        losing = tmp_path / "losing.db"
+        monkeypatch.setenv("CQ_DATABASE_URL", f"sqlite:///{winning}")
+        monkeypatch.setenv("CQ_DB_PATH", str(losing))
+
+        url, path = resolve_sqlite_db_path()
+
+        # Migration URL and runtime path agree — they both target the
+        # CQ_DATABASE_URL DB, never the CQ_DB_PATH one.
+        assert url == f"sqlite:///{winning}"
+        assert path == winning
+
+    def test_non_sqlite_url_is_rejected(self, monkeypatch):
+        monkeypatch.setenv("CQ_DATABASE_URL", "postgresql+psycopg://u:p@h/d")
+
+        with pytest.raises(RuntimeError, match="SQLite"):
+            resolve_sqlite_db_path()
+
+    def test_default_url_resolves_to_default_path(self, monkeypatch):
+        monkeypatch.delenv("CQ_DATABASE_URL", raising=False)
+        monkeypatch.delenv("CQ_DB_PATH", raising=False)
+
+        url, path = resolve_sqlite_db_path()
+
+        assert url == "sqlite:////data/cq.db"
+        assert path == Path("/data/cq.db")

--- a/server/backend/tests/test_migrations.py
+++ b/server/backend/tests/test_migrations.py
@@ -1,0 +1,387 @@
+"""Tests for Alembic baseline migration + stamp-on-startup logic.
+
+Covers the three startup cases the migration runner has to handle:
+
+1. ``test_fresh_database_runs_baseline_migration`` — empty file, no
+   tables. Migration creates everything and stamps at baseline.
+2. ``test_existing_pre_alembic_database_is_stamped`` — production-shape
+   DB built by the legacy ``_ensure_schema()`` path, with seed data in
+   every table. Migration runner must stamp at baseline (not re-run
+   the DDL) and preserve every row.
+3. ``test_already_stamped_database_is_idempotent`` — DB with
+   ``alembic_version`` already at head. Re-running is a no-op.
+
+Plus a fourth structural test:
+
+4. ``test_baseline_schema_matches_legacy_ensure_schema`` — the in-repo
+   substitute for "byte-checked against current production schema".
+   Builds DB-A via legacy ``_ensure_schema`` and DB-B via the baseline
+   migration and asserts they produce the equivalent set of
+   tables/columns/indexes/foreign-keys. **Delete this test in #310**
+   when ``_ensure_schema`` is removed and the migration becomes the
+   sole source of truth.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from cq_server.migrations import BASELINE_REVISION, run_migrations
+from cq_server.store import RemoteStore
+
+# --- Helpers --------------------------------------------------------------
+
+
+def _sqlite_url(db: Path) -> str:
+    return f"sqlite:///{db}"
+
+
+def _open_ro(db: Path) -> sqlite3.Connection:
+    """Open a connection with foreign keys on, matching production PRAGMAs."""
+    conn = sqlite3.connect(str(db))
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def _user_table_names(conn: sqlite3.Connection) -> set[str]:
+    rows = conn.execute("SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'").fetchall()
+    return {row[0] for row in rows}
+
+
+def _alembic_version(conn: sqlite3.Connection) -> str | None:
+    row = conn.execute("SELECT version_num FROM alembic_version").fetchone()
+    return None if row is None else row[0]
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> list[tuple[Any, ...]]:
+    """Return PRAGMA table_info rows ordered by cid (= source order).
+
+    Tuple shape: (name, type, notnull, dflt_value, pk). cid is dropped
+    so the comparison is on the column list itself, not on ordering
+    metadata.
+    """
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return [(row[1], row[2], row[3], row[4], row[5]) for row in rows]
+
+
+def _explicit_indexes(conn: sqlite3.Connection, table: str) -> dict[str, dict[str, Any]]:
+    """Return only `CREATE INDEX` indexes (origin = 'c').
+
+    Implicit `sqlite_autoindex_*` indexes that SQLite generates for
+    PRIMARY KEY / UNIQUE constraints are excluded — those are already
+    accounted for in the column list.
+    """
+    out: dict[str, dict[str, Any]] = {}
+    for row in conn.execute(f"PRAGMA index_list({table})").fetchall():
+        # row: (seq, name, unique, origin, partial)
+        name, unique, origin = row[1], bool(row[2]), row[3]
+        if origin != "c":
+            continue
+        cols = [info[2] for info in conn.execute(f"PRAGMA index_info({name})").fetchall()]
+        out[name] = {"unique": unique, "columns": cols}
+    return out
+
+
+def _foreign_keys(conn: sqlite3.Connection, table: str) -> list[tuple[Any, ...]]:
+    """Return foreign keys ordered by (id, seq) for deterministic compare."""
+    rows = conn.execute(f"PRAGMA foreign_key_list({table})").fetchall()
+    # row: (id, seq, table, from, to, on_update, on_delete, match)
+    sortable = sorted(rows, key=lambda r: (r[0], r[1]))
+    return [(r[2], r[3], r[4], r[5], r[6], r[7]) for r in sortable]
+
+
+def _normalized_table_shape(conn: sqlite3.Connection, table: str) -> dict[str, Any]:
+    """Build a deterministic, comparable shape descriptor for one table."""
+    columns = _columns(conn, table)
+    # SQLite reports notnull differently on PRIMARY KEY columns
+    # depending on whether the source SQL spelled NOT NULL out:
+    # the legacy schema uses bare ``id TEXT PRIMARY KEY`` /
+    # ``id INTEGER PRIMARY KEY AUTOINCREMENT`` (notnull=0), while
+    # SQLAlchemy / Alembic always emit NOT NULL on PK columns
+    # (notnull=1). Functionally equivalent for this application —
+    # the code never inserts NULL into a primary key — so normalize
+    # notnull on PK columns regardless of type.
+    normalized_cols = []
+    for name, type_, notnull, default, pk in columns:
+        if pk:
+            notnull = 0
+        normalized_cols.append((name, type_, notnull, default, pk))
+    return {
+        "columns": normalized_cols,
+        "indexes": _explicit_indexes(conn, table),
+        "foreign_keys": _foreign_keys(conn, table),
+    }
+
+
+def _normalized_schema(conn: sqlite3.Connection) -> dict[str, dict[str, Any]]:
+    """Whole-DB shape descriptor, keyed by user table name."""
+    tables = _user_table_names(conn) - {"alembic_version"}
+    return {t: _normalized_table_shape(conn, t) for t in sorted(tables)}
+
+
+def _row_counts(conn: sqlite3.Connection, tables: set[str]) -> dict[str, int]:
+    return {t: conn.execute(f"SELECT COUNT(*) FROM {t}").fetchone()[0] for t in tables}
+
+
+def _seed_kus(store: RemoteStore) -> list[str]:
+    """Insert three KUs covering different review states and tiers."""
+    from cq.models import Context, Insight, Tier, create_knowledge_unit
+
+    units = [
+        create_knowledge_unit(
+            domains=["api"],
+            insight=Insight(summary="A", detail="A.", action="A!"),
+            context=Context(),
+            tier=Tier.PRIVATE,
+            created_by="alice",
+        ),
+        create_knowledge_unit(
+            domains=["databases"],
+            insight=Insight(summary="B", detail="B.", action="B!"),
+            context=Context(languages=["python"]),
+            tier=Tier.PRIVATE,
+            created_by="alice",
+        ),
+        create_knowledge_unit(
+            domains=["security", "api"],
+            insight=Insight(summary="C", detail="C.", action="C!"),
+            context=Context(),
+            tier=Tier.PRIVATE,
+            created_by="alice",
+        ),
+    ]
+    for u in units:
+        store.insert(u)
+    # Approve one so reviewed_by/reviewed_at are exercised on a real row.
+    store.set_review_status(units[0].id, "approved", "reviewer-bob")
+    return [u.id for u in units]
+
+
+def _seed_user_and_api_key(store: RemoteStore) -> tuple[int, str]:
+    """Insert one user + one API key. Returns (user_id, key_id)."""
+    store.create_user("alice", "$2b$12$fakehashfakehashfakehashfakehashfake")
+    user = store.get_user("alice")
+    assert user is not None
+    user_id = int(user["id"])
+    key_id = uuid.uuid4().hex
+    store.create_api_key(
+        key_id=key_id,
+        user_id=user_id,
+        name="seed",
+        labels=["test"],
+        key_prefix="cqaprefi",
+        key_hash="hash-" + key_id,
+        ttl="30d",
+        expires_at="2099-01-01T00:00:00+00:00",
+    )
+    return user_id, key_id
+
+
+# --- Test 1: fresh database ------------------------------------------------
+
+
+class TestFreshDatabase:
+    def test_fresh_database_runs_baseline_migration(self, tmp_path: Path) -> None:
+        db = tmp_path / "fresh.db"
+        assert not db.exists()
+
+        run_migrations(_sqlite_url(db))
+
+        assert db.exists()
+        with _open_ro(db) as conn:
+            tables = _user_table_names(conn)
+            assert {
+                "knowledge_units",
+                "knowledge_unit_domains",
+                "users",
+                "api_keys",
+                "alembic_version",
+            } <= tables
+            assert _alembic_version(conn) == BASELINE_REVISION
+
+            # knowledge_units columns and order match the historical
+            # _SCHEMA_SQL + ALTER end-state on prod.
+            ku_cols = [c[0] for c in _columns(conn, "knowledge_units")]
+            assert ku_cols == [
+                "id",
+                "data",
+                "status",
+                "reviewed_by",
+                "reviewed_at",
+                "created_at",
+                "tier",
+            ]
+
+            # Defaults on the columns that have them.
+            ku_by_name = {c[0]: c for c in _columns(conn, "knowledge_units")}
+            assert ku_by_name["status"][3] == "'pending'"
+            assert ku_by_name["tier"][3] == "'private'"
+
+            # Explicit indexes.
+            ku_domain_idx = _explicit_indexes(conn, "knowledge_unit_domains")
+            assert "idx_domains_domain" in ku_domain_idx
+            assert ku_domain_idx["idx_domains_domain"]["columns"] == ["domain"]
+            api_key_idx = _explicit_indexes(conn, "api_keys")
+            assert "idx_api_keys_user" in api_key_idx
+            assert api_key_idx["idx_api_keys_user"]["columns"] == ["user_id"]
+
+            # Foreign keys with cascade.
+            fks = _foreign_keys(conn, "knowledge_unit_domains")
+            assert any(fk[0] == "knowledge_units" and fk[1] == "unit_id" and fk[4] == "CASCADE" for fk in fks)
+            api_fks = _foreign_keys(conn, "api_keys")
+            assert any(fk[0] == "users" and fk[1] == "user_id" and fk[4] == "CASCADE" for fk in api_fks)
+
+
+# --- Test 2: existing pre-Alembic database with data -----------------------
+
+
+class TestExistingPreAlembicDatabase:
+    """The critical case: real prod DB has data, no alembic_version."""
+
+    @pytest.fixture()
+    def seeded_pre_alembic_db(self, tmp_path: Path) -> tuple[Path, Mapping[str, Any]]:
+        """Build a production-shape SQLite DB by going through the legacy
+        ``_ensure_schema()`` path, then seed every table and snapshot
+        the resulting state. Returns (db_path, snapshot)."""
+        db = tmp_path / "prod.db"
+        store = RemoteStore(db_path=db)
+        ku_ids = _seed_kus(store)
+        user_id, key_id = _seed_user_and_api_key(store)
+        store.close()
+
+        with _open_ro(db) as conn:
+            assert "alembic_version" not in _user_table_names(conn)
+            data_tables = _user_table_names(conn)
+            snapshot = {
+                "schema": _normalized_schema(conn),
+                "counts": _row_counts(conn, data_tables),
+                "kus": conn.execute(
+                    "SELECT id, data, status, reviewed_by, reviewed_at, created_at, tier "
+                    "FROM knowledge_units ORDER BY id"
+                ).fetchall(),
+                "ku_ids": sorted(ku_ids),
+                "user_id": user_id,
+                "key_id": key_id,
+            }
+        return db, snapshot
+
+    def test_existing_pre_alembic_database_is_stamped(
+        self, seeded_pre_alembic_db: tuple[Path, Mapping[str, Any]]
+    ) -> None:
+        db, before = seeded_pre_alembic_db
+
+        run_migrations(_sqlite_url(db))
+
+        with _open_ro(db) as conn:
+            # Stamp landed at baseline — proves we did NOT re-run the DDL,
+            # otherwise Alembic would have errored on CREATE TABLE
+            # against an existing table.
+            assert _alembic_version(conn) == BASELINE_REVISION
+
+            # Schema for user tables is structurally unchanged.
+            assert _normalized_schema(conn) == before["schema"]
+
+            # Every row preserved.
+            data_tables = _user_table_names(conn) - {"alembic_version"}
+            assert _row_counts(conn, data_tables) == before["counts"]
+
+            # KU rows still exactly equal (every column).
+            assert (
+                conn.execute(
+                    "SELECT id, data, status, reviewed_by, reviewed_at, created_at, tier "
+                    "FROM knowledge_units ORDER BY id"
+                ).fetchall()
+                == before["kus"]
+            )
+
+    def test_pre_alembic_migration_is_idempotent(self, seeded_pre_alembic_db: tuple[Path, Mapping[str, Any]]) -> None:
+        """SIGTERM-during-stamp could land us here; re-running must not
+        corrupt anything."""
+        db, before = seeded_pre_alembic_db
+
+        run_migrations(_sqlite_url(db))
+        # Run a second time on the now-stamped DB.
+        run_migrations(_sqlite_url(db))
+
+        with _open_ro(db) as conn:
+            assert _alembic_version(conn) == BASELINE_REVISION
+            assert _normalized_schema(conn) == before["schema"]
+            data_tables = _user_table_names(conn) - {"alembic_version"}
+            assert _row_counts(conn, data_tables) == before["counts"]
+
+
+# --- Test 3: already-stamped database --------------------------------------
+
+
+class TestAlreadyStampedDatabase:
+    def test_already_stamped_database_is_idempotent(self, tmp_path: Path) -> None:
+        db = tmp_path / "stamped.db"
+
+        # First call: fresh DB → upgrade head.
+        run_migrations(_sqlite_url(db))
+
+        # Insert a sentinel row through a real RemoteStore.
+        store = RemoteStore(db_path=db)
+        try:
+            ku_ids = _seed_kus(store)
+        finally:
+            store.close()
+
+        with _open_ro(db) as conn:
+            counts_before = _row_counts(conn, _user_table_names(conn) - {"alembic_version"})
+            schema_before = _normalized_schema(conn)
+
+        # Second call on the same DB: must be a no-op.
+        run_migrations(_sqlite_url(db))
+
+        with _open_ro(db) as conn:
+            assert _alembic_version(conn) == BASELINE_REVISION
+            data_tables = _user_table_names(conn) - {"alembic_version"}
+            assert _row_counts(conn, data_tables) == counts_before
+            assert _normalized_schema(conn) == schema_before
+            # Sentinel rows survived.
+            ku_rows = conn.execute("SELECT id FROM knowledge_units ORDER BY id").fetchall()
+            assert sorted(r[0] for r in ku_rows) == sorted(ku_ids)
+
+
+# --- Test 4: parity with legacy _ensure_schema -----------------------------
+
+
+class TestBaselineMatchesLegacySchema:
+    """In-repo proxy for #305's "byte-checked against production schema".
+
+    The current ``_ensure_schema()`` is what builds every production DB,
+    so if the baseline migration produces a structurally equivalent
+    schema on an empty file, we have parity with prod.
+
+    DELETE THIS TEST in #310 alongside ``_ensure_schema()`` — once
+    the legacy path is gone there is nothing to compare against and
+    the migration is the sole source of truth.
+    """
+
+    def test_baseline_schema_matches_legacy_ensure_schema(self, tmp_path: Path) -> None:
+        legacy_db = tmp_path / "legacy.db"
+        migrated_db = tmp_path / "migrated.db"
+
+        # DB-A: legacy code path.
+        RemoteStore(db_path=legacy_db).close()
+        # DB-B: baseline migration.
+        run_migrations(_sqlite_url(migrated_db))
+
+        with _open_ro(legacy_db) as conn_a, _open_ro(migrated_db) as conn_b:
+            schema_a = _normalized_schema(conn_a)
+            schema_b = _normalized_schema(conn_b)
+
+        # alembic_version is excluded by _normalized_schema; everything
+        # else must agree.
+        assert schema_b == schema_a, (
+            "Baseline migration drifted from current production schema — "
+            "fix the migration so PRAGMA table_info / PRAGMA index_list / "
+            "PRAGMA foreign_key_list match what _ensure_schema() produces."
+        )

--- a/server/backend/tests/test_migrations.py
+++ b/server/backend/tests/test_migrations.py
@@ -425,6 +425,73 @@ class TestSqliteParentDirCreation:
         assert not Path("/subdir").exists()
 
 
+class TestPercentInUrlIsConfigParserSafe:
+    """Regression: literal ``%`` in the database URL must not crash startup.
+
+    The original implementation called ``cfg.set_main_option(
+    "sqlalchemy.url", url)``, which routes through ConfigParser's
+    interpolation engine and raises ``ValueError: invalid interpolation
+    syntax`` eagerly on any ``%``. Both call sites (``run_migrations``
+    and ``alembic/env.py``) were affected. The fix bypasses the ini
+    option entirely — the runtime hands a connection in via
+    ``cfg.attributes["connection"]`` and the CLI path builds its own
+    engine from a URL resolved at use-time.
+
+    A ``%`` in a SQLite filename exercises the same code path that a
+    ``%``-encoded Postgres password (e.g. ``p%40ss``) would hit, so we
+    can pin the regression without a real database server.
+    """
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "100%real.db",
+            "p%40ss.db",
+            "weird%%name.db",
+        ],
+    )
+    def test_runtime_path_handles_percent_in_url(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, filename: str
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        url = f"sqlite:///{filename}"
+
+        run_migrations(url)
+
+        db = tmp_path / filename
+        assert db.exists()
+        with _open_ro(db) as conn:
+            assert _alembic_version(conn) == BASELINE_REVISION
+
+    def test_cli_path_handles_percent_in_url(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Drives the CLI branch in ``env.py`` — no connection on the Config.
+
+        Without the fix, ``env.py``'s module-level ``set_main_option(
+        "sqlalchemy.url", resolve_database_url())`` would crash on import
+        before any migration ran.
+        """
+        from alembic import command
+        from alembic.config import Config
+
+        from cq_server.migrations import _ALEMBIC_INI
+
+        monkeypatch.chdir(tmp_path)
+        db = tmp_path / "100%real.db"
+        monkeypatch.setenv("CQ_DATABASE_URL", f"sqlite:///{db}")
+        monkeypatch.delenv("CQ_DB_PATH", raising=False)
+
+        cfg = Config(str(_ALEMBIC_INI))
+        # Deliberately do not set ``cfg.attributes["connection"]`` —
+        # this is the path ``alembic upgrade head`` from the shell takes.
+        command.upgrade(cfg, "head")
+
+        assert db.exists()
+        with _open_ro(db) as conn:
+            assert _alembic_version(conn) == BASELINE_REVISION
+
+
 class TestDefaultDatabaseUrlResolution:
     """``run_migrations()`` with no arg must honour ``resolve_database_url``.
 

--- a/server/backend/tests/test_migrations.py
+++ b/server/backend/tests/test_migrations.py
@@ -398,6 +398,33 @@ class TestBaselineMatchesLegacySchema:
 # --- Test 5: default URL resolution ----------------------------------------
 
 
+class TestSqliteParentDirCreation:
+    """Regression: relative ``sqlite:///./data/x.db`` URLs must create
+    ``./data`` (relative to cwd), not an absolute ``/data`` directory.
+
+    The earlier ``urlparse(url).path`` implementation produced
+    ``/./data/x.db`` for that URL, whose ``Path.parent`` is the absolute
+    ``/data`` — so ``mkdir`` either failed with PermissionError outside
+    of Docker or silently created the wrong directory inside it.
+    """
+
+    def test_relative_sqlite_url_creates_relative_parent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        rel_db = "subdir/nested.db"
+        url = f"sqlite:///{rel_db}"
+        assert not (tmp_path / "subdir").exists()
+
+        run_migrations(url)
+
+        # Parent directory was created relative to cwd, not at filesystem root.
+        assert (tmp_path / "subdir").is_dir()
+        assert (tmp_path / rel_db).exists()
+        # Filesystem root must not have been touched.
+        assert not Path("/subdir").exists()
+
+
 class TestDefaultDatabaseUrlResolution:
     """``run_migrations()`` with no arg must honour ``resolve_database_url``.
 

--- a/server/backend/tests/test_migrations.py
+++ b/server/backend/tests/test_migrations.py
@@ -360,6 +360,14 @@ class TestBaselineMatchesLegacySchema:
     so if the baseline migration produces a structurally equivalent
     schema on an empty file, we have parity with prod.
 
+    Caveat: ``_normalized_table_shape`` deliberately normalises NOT-NULL
+    on PRIMARY KEY columns to ``0`` because the legacy schema and
+    SQLAlchemy/Alembic disagree on whether to spell ``NOT NULL`` out for
+    PKs. This is load-bearing — the parity check accepts any future
+    PK-nullability divergence as well, including bugs introduced by a
+    new migration. Future migrations that touch PK columns should be
+    reviewed against the migration source, not just this test.
+
     DELETE THIS TEST in #310 alongside ``_ensure_schema()`` — once
     the legacy path is gone there is nothing to compare against and
     the migration is the sole source of truth.
@@ -385,3 +393,39 @@ class TestBaselineMatchesLegacySchema:
             "fix the migration so PRAGMA table_info / PRAGMA index_list / "
             "PRAGMA foreign_key_list match what _ensure_schema() produces."
         )
+
+
+# --- Test 5: default URL resolution ----------------------------------------
+
+
+class TestDefaultDatabaseUrlResolution:
+    """``run_migrations()`` with no arg must honour ``resolve_database_url``.
+
+    The startup path in ``app.py`` calls ``run_migrations()`` with no
+    argument so that ``CQ_DATABASE_URL`` (and the ``CQ_DB_PATH``
+    fallback) take effect. Cover both env-var branches.
+    """
+
+    def test_run_migrations_uses_cq_db_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        db = tmp_path / "from_env.db"
+        monkeypatch.delenv("CQ_DATABASE_URL", raising=False)
+        monkeypatch.setenv("CQ_DB_PATH", str(db))
+
+        run_migrations()
+
+        assert db.exists()
+        with _open_ro(db) as conn:
+            assert _alembic_version(conn) == BASELINE_REVISION
+
+    def test_cq_database_url_takes_precedence_over_cq_db_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        winning = tmp_path / "winning.db"
+        losing = tmp_path / "losing.db"
+        monkeypatch.setenv("CQ_DATABASE_URL", _sqlite_url(winning))
+        monkeypatch.setenv("CQ_DB_PATH", str(losing))
+
+        run_migrations()
+
+        assert winning.exists()
+        assert not losing.exists()


### PR DESCRIPTION
Closes #305. Part of the [PostgreSQL-backend epic](https://github.com/mozilla-ai/cq/issues/257) (phase 1).

## Summary

Lands the Alembic baseline for the schema currently produced by `_ensure_schema()` and a startup runner that brings the DB under Alembic management. Three cases handled:

1. **Fresh DB** — `upgrade head` creates everything from the baseline migration.
2. **Pre-Alembic prod DB** — schema already exists with no `alembic_version` table; runner *stamps* at baseline (single insert, no DDL re-run, no data touched) then upgrades.
3. **Already-stamped DB** — `upgrade head` is a no-op; restart is idempotent.

The legacy `_ensure_schema()` still runs after the migration during the rollout window and will be removed in #310. Both paths are idempotent.

## Why

Phase-1 of the Postgres epic needs the schema under Alembic before the runtime store can target Postgres (#309) or async drivers (#311). Stamping (rather than re-creating) means existing prod DBs adopt the migration with zero downtime and no data risk.

## What's in the migration

Reverse-engineered union of:
- `cq_server.store._SCHEMA_SQL` (`knowledge_units`, `knowledge_unit_domains`, `idx_domains_domain`)
- `cq_server.tables._REVIEW_COLUMN_STATEMENTS` (the trailing `ALTER TABLE … ADD COLUMN` suite)
- `cq_server.tables.USERS_TABLE_SQL` and `API_KEYS_TABLE_SQL`

Column order, defaults, and FK cascade behaviour mirror what's on disk in production. The migration carries a "do not edit after merge" warning — once production DBs are stamped at `0001`, any change here would diverge from disk.

## Tests

- **Fresh DB** — verifies all tables, default values, indexes, FK cascades, and `alembic_version == "0001"`.
- **Pre-Alembic with data** — builds a prod-shape DB through the legacy path, seeds every table (KUs, users, API keys, review state), runs the migration, asserts every row preserved and the schema is structurally unchanged.
- **Idempotent re-run** — covers SIGTERM-during-stamp recovery.
- **Already-stamped** — second invocation is a no-op.
- **Parity with `_ensure_schema`** — in-repo proxy for "byte-checked against production schema"; deletes itself in #310 when the legacy path is gone.
- **Default URL resolution** — `CQ_DB_PATH` fallback and `CQ_DATABASE_URL` precedence.

## Test plan

- [ ] `make test-server-backend` — 213 pass locally
- [ ] `make lint-server-backend` — ruff + ty clean
- [ ] Verify staging restart picks up baseline stamp without re-running DDL (check `alembic_version` row appears, no schema diff)
- [ ] Confirm fresh-deploy path creates schema via migration (e.g. ephemeral env)

## Follow-ups

- #309 — wire runtime store to `CQ_DATABASE_URL`
- #310 — remove legacy `_ensure_schema()` and the parity test
- #311 — Postgres + async driver

🤖 Generated with [Claude Code](https://claude.com/claude-code)