### PR TITLE
sdk/go: pin schema dependency to published version

### DIFF
--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/mozilla-ai/cq/schema v0.0.0-00010101000000-000000000000
+	github.com/mozilla-ai/cq/schema v0.0.1
 	github.com/stretchr/testify v1.11.1
 	modernc.org/sqlite v1.48.0
 )
@@ -23,4 +23,5 @@ require (
 	modernc.org/memory v1.11.0 // indirect
 )
 
-replace github.com/mozilla-ai/cq/schema => ../../schema
+// For local in-repo development before publishing a new schema release:
+//replace github.com/mozilla-ai/cq/schema => ../../schema

--- a/sdk/go/go.sum
+++ b/sdk/go/go.sum
@@ -10,6 +10,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mozilla-ai/cq/schema v0.0.1 h1:jPoZAYbU7/b3R3CEghmwuG0A3NrqczWsMkIWjXeFI94=
+github.com/mozilla-ai/cq/schema v0.0.1/go.mod h1:trKUR0o8hGYkQ26XAb3HFVHcQOct7lP/cS8beS5v2eE=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## Summary
- Pin `github.com/mozilla-ai/cq/schema` in `sdk/go/go.mod` to the first published schema release (`v0.0.1`) instead of the temporary zero pseudo-version.
- Drop the active local `replace` override and keep a commented local-dev `replace` hint so in-repo development remains easy before future schema releases.
- Regenerate module sums with `go mod tidy` and verify with `make test-sdk-go`.

Closes #331