### PR TITLE
server: wire CQ_DATABASE_URL + store factory (#309)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -177,7 +177,8 @@ Running the server (see `server/`) requires:
 |----------|----------|---------|---------|
 | `CQ_JWT_SECRET` | Yes | — | Secret used to sign JWTs issued by `/auth/login`. |
 | `CQ_API_KEY_PEPPER` | Yes | — | Server-side pepper combined with each API key under HMAC-SHA256. |
-| `CQ_DB_PATH` | No | `/data/cq.db` | Path to the SQLite database. |
+| `CQ_DATABASE_URL` | No | — | SQLAlchemy URL for the backing database. Currently only `sqlite:///<path>` is supported; `postgresql+psycopg://...` is reserved for the upcoming PostgreSQL backend ([epic #257](https://github.com/mozilla-ai/cq/issues/257)) and rejected at startup. |
+| `CQ_DB_PATH` | No | `/data/cq.db` | Shortcut for SQLite deployments — wrapped as `sqlite:///<path>` internally. Used when `CQ_DATABASE_URL` is unset. |
 | `CQ_PORT` | No | `3000` | HTTP listen port. |
 
 API keys are created per user from the web UI: log in, open **API Keys**, give the key a name, choose a TTL, and copy the plaintext token when it is shown. The token is displayed exactly once. Set it as `CQ_API_KEY` on each client (plugin, SDK, CLI) that should authenticate against this server.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     environment:
       CQ_JWT_SECRET: ${CQ_JWT_SECRET:?Set CQ_JWT_SECRET in .env}
       CQ_API_KEY_PEPPER: ${CQ_API_KEY_PEPPER:?Set CQ_API_KEY_PEPPER in .env}
+      # CQ_DATABASE_URL: ${CQ_DATABASE_URL:-}  # SQLAlchemy URL; wins over CQ_DB_PATH when set.
       CQ_DB_PATH: ${CQ_DB_PATH:-/data/cq.db}
       CQ_PORT: ${CQ_PORT:-3000}
     ports:

--- a/server/backend/README.md
+++ b/server/backend/README.md
@@ -32,16 +32,19 @@ three cases:
 3. **Already-managed database** — `upgrade head` is a no-op when
    there are no pending revisions, so restart is idempotent.
 
-Database URL resolution (used by `alembic/env.py`, the migration
-runner, and — in a later child issue — the runtime store factory)
-lives in `cq_server.db_url.resolve_database_url`. Precedence:
+Database URL resolution lives in
+`cq_server.db_url.resolve_database_url` and is the single source of
+truth for both `alembic/env.py`, the migration runner, and the
+runtime store factory (`cq_server.store.create_store`). Precedence:
 
-1. `CQ_DATABASE_URL` — used verbatim. **Today this must be a SQLite
-   URL** (e.g. `sqlite:////data/cq.db`); the runtime store is still
-   SQLite-only and the server rejects non-SQLite URLs at startup.
-   Postgres support lands with #309/#311.
-2. `CQ_DB_PATH` — wrapped as `sqlite:///<path>` (back-compat with
-   the existing env var).
+1. `CQ_DATABASE_URL` — used verbatim. SQLite URLs
+   (`sqlite:///<path>`) work today; `postgresql+psycopg://...` is
+   reserved for the Postgres backend and currently rejected at
+   startup with a `NotImplementedError` pointing at the Phase 2
+   child issues ([#311][issue-311] / [#312][issue-312]).
+2. `CQ_DB_PATH` — wrapped as `sqlite:///<path>`. The SQLite shortcut
+   for single-instance deployments; stays supported indefinitely
+   alongside `CQ_DATABASE_URL`.
 3. Default — `sqlite:////data/cq.db`.
 
 The `SqliteStore` constructor still calls the legacy
@@ -63,7 +66,9 @@ CQ_DB_PATH=./dev.db uv run alembic current   # show current revision
 CQ_DB_PATH=./dev.db uv run alembic upgrade head
 ```
 
-Full environment-variable documentation will land alongside the
-`CQ_DATABASE_URL` runtime wiring in a later phase-1 child issue.
+The full environment-variable table for self-hosters lives in
+[DEVELOPMENT.md](../../DEVELOPMENT.md#self-hosted-server).
 
 [issue-310]: https://github.com/mozilla-ai/cq/issues/310
+[issue-311]: https://github.com/mozilla-ai/cq/issues/311
+[issue-312]: https://github.com/mozilla-ai/cq/issues/312

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -88,7 +88,15 @@ async def lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
     # migration 0001 instead of being stamped at baseline.
     database_url = resolve_database_url()
     new_store = create_store(database_url)
-    run_migrations(database_url)
+    # Close ``new_store`` if migrations fail — otherwise its engine and
+    # SQLite file handle leak across in-process lifespan re-entries
+    # (tests, restart loops). The post-yield ``finally`` only covers
+    # successful boots.
+    try:
+        run_migrations(database_url)
+    except BaseException:
+        await new_store.close()
+        raise
     # Assign the global only after both startup steps succeed, so a
     # failure mid-boot doesn't leave a half-initialised ``_store``
     # leaking from the previous lifespan (matters when tests re-enter

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -83,11 +83,17 @@ async def lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
     # equivalent — the legacy idempotent ``_ensure_schema()`` inside
     # ``SqliteStore`` creates the tables, then ``run_migrations`` sees
     # them, stamps baseline and upgrades to head (a no-op today).
-    # The legacy path goes away in #310 and the order can be flipped
-    # back to migrations-first then.
+    # TODO(#310): once the legacy ``_ensure_schema()`` path is gone,
+    # flip back to migrations-first so fresh installs actually exercise
+    # migration 0001 instead of being stamped at baseline.
     database_url = resolve_database_url()
-    _store = create_store(database_url)
+    new_store = create_store(database_url)
     run_migrations(database_url)
+    # Assign the global only after both startup steps succeed, so a
+    # failure mid-boot doesn't leave a half-initialised ``_store``
+    # leaking from the previous lifespan (matters when tests re-enter
+    # ``lifespan`` in-process after a startup failure).
+    _store = new_store
     app_instance.state.store = _store
     app_instance.state.api_key_pepper = pepper
     try:

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -21,12 +21,12 @@ from pydantic import BaseModel, Field
 from starlette.responses import FileResponse
 
 from .auth import router as auth_router
-from .db_url import resolve_sqlite_db_path
+from .db_url import resolve_database_url
 from .deps import API_KEY_PEPPER_ENV, require_api_key
 from .migrations import run_migrations
 from .review import router as review_router
 from .scoring import apply_confirmation, apply_flag
-from .store import SqliteStore, Store, normalize_domains
+from .store import Store, create_store, normalize_domains
 
 _STATIC_DIR = Path(__file__).parent / "static"
 
@@ -74,20 +74,20 @@ async def lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
     pepper = os.environ.get(API_KEY_PEPPER_ENV, "")
     if not pepper:
         raise RuntimeError(f"{API_KEY_PEPPER_ENV} environment variable is required")
-    # Resolve URL and filesystem path together so the migration runner
-    # and the runtime store cannot diverge on which database they're
-    # using — see ``resolve_sqlite_db_path``. This drops once #309
-    # wires ``SqliteStore`` to ``CQ_DATABASE_URL`` directly.
-    database_url, db_path = resolve_sqlite_db_path()
-    # Bring the database under Alembic management before opening the
-    # store. Three cases handled: fresh DB → upgrade head; pre-Alembic
-    # DB → stamp baseline + upgrade head; already-stamped DB → upgrade
-    # head (no-op when no pending revisions). The legacy
-    # ``_ensure_schema()`` inside SqliteStore still runs after this;
-    # both paths are idempotent and the legacy one will be removed in
-    # #310 once this PR has rolled out everywhere.
+    # Single URL feeds both the store factory and the migration runner,
+    # so they can't diverge on which database they target. Run the
+    # factory first: it's the one place that maps URL → backend, and we
+    # want a Postgres URL to surface its ``NotImplementedError`` with
+    # #311/#312 guidance rather than failing inside Alembic with a
+    # raw psycopg ``ModuleNotFoundError``. SQLite ordering is
+    # equivalent — the legacy idempotent ``_ensure_schema()`` inside
+    # ``SqliteStore`` creates the tables, then ``run_migrations`` sees
+    # them, stamps baseline and upgrades to head (a no-op today).
+    # The legacy path goes away in #310 and the order can be flipped
+    # back to migrations-first then.
+    database_url = resolve_database_url()
+    _store = create_store(database_url)
     run_migrations(database_url)
-    _store = SqliteStore(db_path=db_path)
     app_instance.state.store = _store
     app_instance.state.api_key_pepper = pepper
     try:

--- a/server/backend/src/cq_server/db_url.py
+++ b/server/backend/src/cq_server/db_url.py
@@ -3,9 +3,6 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
-
-from sqlalchemy.engine import make_url
 
 _DEFAULT_SQLITE_PATH = "/data/cq.db"
 
@@ -23,27 +20,3 @@ def resolve_database_url() -> str:
         return url
     path = os.environ.get("CQ_DB_PATH", _DEFAULT_SQLITE_PATH)
     return f"sqlite:///{path}"
-
-
-def resolve_sqlite_db_path() -> tuple[str, Path]:
-    """Return ``(url, path)`` for the cq SQLite database.
-
-    Used by the FastAPI lifespan to drive both the migration runner and
-    the ``SqliteStore`` from the same source — without this, setting
-    ``CQ_DATABASE_URL`` would migrate one database while the runtime
-    store opened another. Until the Postgres store lands (#309/#311)
-    the runtime is SQLite-only, so a non-SQLite URL is rejected here
-    rather than silently misconfiguring the server.
-    """
-    url = resolve_database_url()
-    parsed = make_url(url)
-    if not parsed.drivername.startswith("sqlite"):
-        raise RuntimeError(
-            f"CQ_DATABASE_URL must be a SQLite URL until the Postgres store "
-            f"lands (#309/#311); got driver {parsed.drivername!r}."
-        )
-    if not parsed.database or parsed.database == ":memory:":
-        raise RuntimeError(
-            "CQ_DATABASE_URL must point at a SQLite file; in-memory and blank databases are not supported."
-        )
-    return url, Path(parsed.database)

--- a/server/backend/src/cq_server/migrations.py
+++ b/server/backend/src/cq_server/migrations.py
@@ -57,10 +57,10 @@ _ALEMBIC_INI = _find_alembic_ini()
 def _ensure_sqlite_parent_dir(url: str) -> None:
     """Create the parent directory of a sqlite file URL if missing.
 
-    Until #309 wires the runtime store to ``CQ_DATABASE_URL``, the
-    server still mkdir's the SQLite parent inside ``SqliteStore``;
-    but the migration runs first now, so we hoist the directory
-    creation here. No-op for non-sqlite URLs.
+    The migration runs before the store is constructed, so directory
+    creation has to happen here too — ``SqliteStore.__init__`` also
+    mkdir's the parent, but Alembic would crash first if the path
+    didn't exist. No-op for non-sqlite URLs.
     """
     if not url.startswith("sqlite:"):
         return
@@ -81,8 +81,8 @@ def run_migrations(database_url: str | None = None) -> None:
     Assumes a single caller per database — concurrent invocations across
     replicas can race on the table-presence check and on ``upgrade``
     itself. Safe for the current single-instance SQLite deployment;
-    #309/#311 will revisit (likely via ``pg_advisory_lock``) when
-    Postgres + multi-replica land.
+    #313 will revisit (via ``pg_advisory_lock``) when Postgres +
+    multi-replica land.
 
     Args:
         database_url: SQLAlchemy URL to migrate. Defaults to the value
@@ -100,7 +100,7 @@ def run_migrations(database_url: str | None = None) -> None:
     # latter routes through ConfigParser's interpolation engine, which
     # raises ``ValueError: invalid interpolation syntax`` eagerly on any
     # literal ``%`` in the URL — a foot-gun once URL-encoded passwords
-    # land with Postgres in #309/#311, and already triggerable today by
+    # land with Postgres in #311/#312, and already triggerable today by
     # a SQLite filename containing ``%``. ``env.py`` picks up the
     # connection before it tries to build its own engine.
     engine = create_engine(url)

--- a/server/backend/src/cq_server/migrations.py
+++ b/server/backend/src/cq_server/migrations.py
@@ -57,19 +57,24 @@ _ALEMBIC_INI = _find_alembic_ini()
 def _ensure_sqlite_parent_dir(url: str) -> None:
     """Create the parent directory of a sqlite file URL if missing.
 
-    The migration runs before the store is constructed, so directory
-    creation has to happen here too — ``SqliteStore.__init__`` also
-    mkdir's the parent, but Alembic would crash first if the path
-    didn't exist. No-op for non-sqlite URLs.
+    Defensive coverage for callers that invoke ``run_migrations(url)``
+    standalone (CLI, ops scripts, ad-hoc tests) without first
+    constructing a ``SqliteStore``. The lifespan path goes through the
+    store first today, and ``SqliteStore.__init__`` mkdir's the parent
+    itself, but keeping the mkdir here means standalone migration runs
+    don't have to know about that. No-op for non-sqlite URLs.
     """
-    if not url.startswith("sqlite:"):
-        return
     # Use SQLAlchemy's URL parser rather than urlparse: it correctly
     # round-trips both absolute (`sqlite:////abs/path`) and relative
     # (`sqlite:///./rel.db`) SQLite URLs to a usable filesystem path,
     # whereas `urlparse(...).path` prefixes a stray `/` that turns
-    # `./data/dev.db` into the absolute `/data/dev.db`.
-    database = make_url(url).database
+    # `./data/dev.db` into the absolute `/data/dev.db`. Parsing the URL
+    # also lets us catch driver-suffixed schemes like
+    # ``sqlite+pysqlite://`` that a naive ``startswith("sqlite:")`` miss.
+    parsed = make_url(url)
+    if not parsed.drivername.startswith("sqlite"):
+        return
+    database = parsed.database
     if not database or database == ":memory:":
         return
     Path(database).parent.mkdir(parents=True, exist_ok=True)

--- a/server/backend/src/cq_server/store/__init__.py
+++ b/server/backend/src/cq_server/store/__init__.py
@@ -18,8 +18,6 @@ __all__ = [
     "normalize_domains",
 ]
 
-_POSTGRES_DRIVERS = frozenset({"postgresql", "postgresql+psycopg"})
-
 
 def create_store(database_url: str) -> Store:
     """Return the concrete ``Store`` for ``database_url``.
@@ -47,7 +45,13 @@ def create_store(database_url: str) -> Store:
                 "needs a persistent file path."
             )
         return SqliteStore(db_path=Path(parsed.database))
-    if driver in _POSTGRES_DRIVERS:
+    # Match every Postgres driver suffix (``+psycopg``, ``+psycopg2``,
+    # ``+asyncpg``, …) so a typo'd driver still hits the helpful
+    # NotImplementedError instead of falling through to the generic
+    # "unsupported scheme" branch. Phase 2 (#311) will pick the actual
+    # driver; until then anything postgres-shaped is rejected the same
+    # way.
+    if driver == "postgresql" or driver.startswith("postgresql+"):
         raise NotImplementedError(
             "PostgreSQL backend is not implemented yet; lands with "
             "PostgresStore in epic #257 (issues #311/#312)."

--- a/server/backend/src/cq_server/store/__init__.py
+++ b/server/backend/src/cq_server/store/__init__.py
@@ -1,5 +1,11 @@
 """Store package: protocol + concrete backends."""
 
+from __future__ import annotations
+
+from pathlib import Path
+
+from sqlalchemy.engine import make_url
+
 from ._normalize import normalize_domains
 from ._protocol import Store
 from ._sqlite import DEFAULT_DB_PATH, SqliteStore
@@ -8,5 +14,42 @@ __all__ = [
     "DEFAULT_DB_PATH",
     "SqliteStore",
     "Store",
+    "create_store",
     "normalize_domains",
 ]
+
+_POSTGRES_DRIVERS = frozenset({"postgresql", "postgresql+psycopg"})
+
+
+def create_store(database_url: str) -> Store:
+    """Return the concrete ``Store`` for ``database_url``.
+
+    Single dispatch point for URL → backend selection so the FastAPI
+    lifespan and any future Postgres caller can't drift on which scheme
+    maps to which store.
+
+    SQLite URLs return a live ``SqliteStore``. Postgres URLs raise
+    ``NotImplementedError`` until the Phase 2 ``PostgresStore`` lands
+    (#311/#312); the message names those issues so the failure is
+    self-explanatory. Anything else raises ``ValueError`` with the
+    offending driver string.
+    """
+    parsed = make_url(database_url)
+    driver = parsed.drivername
+    if driver.startswith("sqlite"):
+        if not parsed.database:
+            raise ValueError(
+                "SQLite URL must point at a file path; got an empty database."
+            )
+        if parsed.database == ":memory:":
+            raise ValueError(
+                "in-memory SQLite databases are not supported; the cq server "
+                "needs a persistent file path."
+            )
+        return SqliteStore(db_path=Path(parsed.database))
+    if driver in _POSTGRES_DRIVERS:
+        raise NotImplementedError(
+            "PostgreSQL backend is not implemented yet; lands with "
+            "PostgresStore in epic #257 (issues #311/#312)."
+        )
+    raise ValueError(f"Unsupported database URL scheme: {driver!r}")

--- a/server/backend/src/cq_server/store/__init__.py
+++ b/server/backend/src/cq_server/store/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from sqlalchemy.engine import make_url
+from sqlalchemy.exc import ArgumentError
 
 from ._normalize import normalize_domains
 from ._protocol import Store
@@ -32,7 +33,10 @@ def create_store(database_url: str) -> Store:
     self-explanatory. Anything else raises ``ValueError`` with the
     offending driver string.
     """
-    parsed = make_url(database_url)
+    try:
+        parsed = make_url(database_url)
+    except ArgumentError as exc:
+        raise ValueError(f"Invalid CQ_DATABASE_URL: {database_url!r}") from exc
     driver = parsed.drivername
     if driver.startswith("sqlite"):
         if not parsed.database:

--- a/server/backend/tests/test_app.py
+++ b/server/backend/tests/test_app.py
@@ -395,6 +395,52 @@ class TestEndToEnd:
         assert resp.json()["total_units"] == 1
 
 
+class TestDatabaseUrlBoot:
+    """Smoke-tests for #309 — server boots under each env-var combo.
+
+    Three boots, one per branch of ``resolve_database_url`` precedence.
+    The contract is that ``CQ_DATABASE_URL`` wins over ``CQ_DB_PATH``
+    when both are set, and that either one in isolation also brings up
+    a working server.
+    """
+
+    def _boot_and_health(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-please-ignore-len")
+        monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+        with TestClient(app) as c:
+            assert c.get("/health").status_code == 200
+
+    def test_boots_with_only_cq_db_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CQ_DATABASE_URL", raising=False)
+        monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "legacy.db"))
+        self._boot_and_health(monkeypatch)
+        assert (tmp_path / "legacy.db").exists()
+
+    def test_boots_with_cq_database_url(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CQ_DB_PATH", raising=False)
+        winning = tmp_path / "from_url.db"
+        monkeypatch.setenv("CQ_DATABASE_URL", f"sqlite:///{winning}")
+        self._boot_and_health(monkeypatch)
+        assert winning.exists()
+
+    def test_cq_database_url_wins_over_cq_db_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        winning = tmp_path / "winning.db"
+        losing = tmp_path / "losing.db"
+        monkeypatch.setenv("CQ_DATABASE_URL", f"sqlite:///{winning}")
+        monkeypatch.setenv("CQ_DB_PATH", str(losing))
+        self._boot_and_health(monkeypatch)
+        assert winning.exists()
+        assert not losing.exists()
+
+    def test_postgres_url_fails_fast_with_guidance(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-please-ignore-len")
+        monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+        monkeypatch.setenv("CQ_DATABASE_URL", "postgresql+psycopg://u:p@h/d")
+        with pytest.raises(NotImplementedError, match="#311"):
+            with TestClient(app):
+                pass
+
+
 class TestApiKeyEnforcement:
     def test_propose_without_key_is_rejected(self, enforced_client: TestClient) -> None:
         resp = enforced_client.post("/propose", json=_propose_payload())

--- a/server/backend/tests/test_app.py
+++ b/server/backend/tests/test_app.py
@@ -436,9 +436,8 @@ class TestDatabaseUrlBoot:
         monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-please-ignore-len")
         monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
         monkeypatch.setenv("CQ_DATABASE_URL", "postgresql+psycopg://u:p@h/d")
-        with pytest.raises(NotImplementedError, match="#311"):
-            with TestClient(app):
-                pass
+        with pytest.raises(NotImplementedError, match="not implemented"), TestClient(app):
+            pass
 
 
 class TestApiKeyEnforcement:

--- a/server/backend/tests/test_app.py
+++ b/server/backend/tests/test_app.py
@@ -436,8 +436,11 @@ class TestDatabaseUrlBoot:
         monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-please-ignore-len")
         monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
         monkeypatch.setenv("CQ_DATABASE_URL", "postgresql+psycopg://u:p@h/d")
-        with pytest.raises(NotImplementedError, match="not implemented"), TestClient(app):
+        with pytest.raises(NotImplementedError) as exc, TestClient(app):
             pass
+        message = str(exc.value)
+        assert "#311" in message
+        assert "#312" in message
 
 
 class TestApiKeyEnforcement:

--- a/server/backend/tests/test_db_url.py
+++ b/server/backend/tests/test_db_url.py
@@ -1,10 +1,6 @@
 """Tests for resolve_database_url()."""
 
-from pathlib import Path
-
-import pytest
-
-from cq_server.db_url import resolve_database_url, resolve_sqlite_db_path
+from cq_server.db_url import resolve_database_url
 
 
 def test_explicit_database_url_wins(monkeypatch):
@@ -33,49 +29,3 @@ def test_empty_database_url_falls_through(monkeypatch, tmp_path):
     monkeypatch.setenv("CQ_DATABASE_URL", "")
     monkeypatch.setenv("CQ_DB_PATH", str(db))
     assert resolve_database_url() == f"sqlite:///{db}"
-
-
-class TestResolveSqliteDbPath:
-    """``resolve_sqlite_db_path`` is the single source of truth for both the
-    migration URL and the runtime store's filesystem path during the
-    rollout window. Any divergence here is a footgun: migrations would
-    target one DB while the server reads/writes another.
-    """
-
-    def test_returns_url_and_path_for_cq_db_path(self, monkeypatch, tmp_path):
-        monkeypatch.delenv("CQ_DATABASE_URL", raising=False)
-        db = tmp_path / "cq.db"
-        monkeypatch.setenv("CQ_DB_PATH", str(db))
-
-        url, path = resolve_sqlite_db_path()
-
-        assert url == f"sqlite:///{db}"
-        assert path == db
-
-    def test_cq_database_url_governs_both_url_and_path(self, monkeypatch, tmp_path):
-        winning = tmp_path / "winning.db"
-        losing = tmp_path / "losing.db"
-        monkeypatch.setenv("CQ_DATABASE_URL", f"sqlite:///{winning}")
-        monkeypatch.setenv("CQ_DB_PATH", str(losing))
-
-        url, path = resolve_sqlite_db_path()
-
-        # Migration URL and runtime path agree — they both target the
-        # CQ_DATABASE_URL DB, never the CQ_DB_PATH one.
-        assert url == f"sqlite:///{winning}"
-        assert path == winning
-
-    def test_non_sqlite_url_is_rejected(self, monkeypatch):
-        monkeypatch.setenv("CQ_DATABASE_URL", "postgresql+psycopg://u:p@h/d")
-
-        with pytest.raises(RuntimeError, match="SQLite"):
-            resolve_sqlite_db_path()
-
-    def test_default_url_resolves_to_default_path(self, monkeypatch):
-        monkeypatch.delenv("CQ_DATABASE_URL", raising=False)
-        monkeypatch.delenv("CQ_DB_PATH", raising=False)
-
-        url, path = resolve_sqlite_db_path()
-
-        assert url == "sqlite:////data/cq.db"
-        assert path == Path("/data/cq.db")

--- a/server/backend/tests/test_store_factory.py
+++ b/server/backend/tests/test_store_factory.py
@@ -76,3 +76,9 @@ class TestUnknownScheme:
     def test_unknown_scheme_rejected(self) -> None:
         with pytest.raises(ValueError, match="mysql"):
             create_store("mysql://u:p@h/d")
+
+
+class TestMalformedUrl:
+    def test_malformed_url_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Invalid CQ_DATABASE_URL"):
+            create_store("not a url")

--- a/server/backend/tests/test_store_factory.py
+++ b/server/backend/tests/test_store_factory.py
@@ -50,19 +50,26 @@ class TestSqlite:
 
 
 class TestPostgres:
-    def test_postgres_psycopg_url_raises_not_implemented(self) -> None:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            # Bare ``postgresql://`` is a common copy-paste from libpq URLs;
+            # the explicit driver suffixes cover the drivers users actually
+            # paste — psycopg v3 (#311's target), psycopg2 (still ubiquitous),
+            # and asyncpg. All four must hit the same NotImplementedError so
+            # the #311/#312 pointer is the user's first signal rather than a
+            # generic "unsupported scheme" or a SQLAlchemy dialect-load
+            # failure.
+            "postgresql://u:p@h/d",
+            "postgresql+psycopg://u:p@h/d",
+            "postgresql+psycopg2://u:p@h/d",
+            "postgresql+asyncpg://u:p@h/d",
+        ],
+    )
+    def test_postgres_url_raises_not_implemented_with_guidance(self, url: str) -> None:
         with pytest.raises(NotImplementedError) as exc:
-            create_store("postgresql+psycopg://u:p@h/d")
-        # The message must point at the Phase 2 children so users hit a
-        # self-explanatory error rather than a "did I typo my URL?" loop.
+            create_store(url)
         assert "#311" in str(exc.value) or "#312" in str(exc.value)
-
-    def test_bare_postgresql_url_also_raises_not_implemented(self) -> None:
-        # Bare ``postgresql://`` (no driver) is a common copy-paste from
-        # libpq URLs; rejecting it with the same NotImplementedError
-        # avoids dropping the user into a SQLAlchemy dialect-load failure.
-        with pytest.raises(NotImplementedError):
-            create_store("postgresql://u:p@h/d")
 
 
 class TestUnknownScheme:

--- a/server/backend/tests/test_store_factory.py
+++ b/server/backend/tests/test_store_factory.py
@@ -1,0 +1,71 @@
+"""Tests for the ``create_store`` URL → backend factory.
+
+Covers the dispatch contract spelled out in #309: SQLite URLs return a
+working ``SqliteStore``, Postgres URLs raise ``NotImplementedError`` with
+guidance pointing at the Phase 2 child issues, and unsupported schemes
+raise ``ValueError``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from cq.models import Insight, create_knowledge_unit
+
+from cq_server.store import SqliteStore, create_store
+
+
+class TestSqlite:
+    async def test_sqlite_url_returns_sqlite_store(self, tmp_path: Path) -> None:
+        db = tmp_path / "factory.db"
+        store = create_store(f"sqlite:///{db}")
+        try:
+            assert isinstance(store, SqliteStore)
+            unit = create_knowledge_unit(
+                domains=["factory"],
+                insight=Insight(summary="s", detail="d", action="a"),
+            )
+            await store.insert(unit)
+            assert await store.get_any(unit.id) is not None
+            assert db.exists()
+        finally:
+            await store.close()
+
+    async def test_sqlite_url_creates_parent_directory(self, tmp_path: Path) -> None:
+        nested = tmp_path / "a" / "b" / "c.db"
+        store = create_store(f"sqlite:///{nested}")
+        try:
+            assert nested.parent.is_dir()
+        finally:
+            await store.close()
+
+    def test_blank_sqlite_database_rejected(self) -> None:
+        with pytest.raises(ValueError, match="file path"):
+            create_store("sqlite:///")
+
+    def test_in_memory_sqlite_rejected(self) -> None:
+        with pytest.raises(ValueError, match="in-memory"):
+            create_store("sqlite:///:memory:")
+
+
+class TestPostgres:
+    def test_postgres_psycopg_url_raises_not_implemented(self) -> None:
+        with pytest.raises(NotImplementedError) as exc:
+            create_store("postgresql+psycopg://u:p@h/d")
+        # The message must point at the Phase 2 children so users hit a
+        # self-explanatory error rather than a "did I typo my URL?" loop.
+        assert "#311" in str(exc.value) or "#312" in str(exc.value)
+
+    def test_bare_postgresql_url_also_raises_not_implemented(self) -> None:
+        # Bare ``postgresql://`` (no driver) is a common copy-paste from
+        # libpq URLs; rejecting it with the same NotImplementedError
+        # avoids dropping the user into a SQLAlchemy dialect-load failure.
+        with pytest.raises(NotImplementedError):
+            create_store("postgresql://u:p@h/d")
+
+
+class TestUnknownScheme:
+    def test_unknown_scheme_rejected(self) -> None:
+        with pytest.raises(ValueError, match="mysql"):
+            create_store("mysql://u:p@h/d")

--- a/server/backend/tests/test_store_factory.py
+++ b/server/backend/tests/test_store_factory.py
@@ -69,7 +69,9 @@ class TestPostgres:
     def test_postgres_url_raises_not_implemented_with_guidance(self, url: str) -> None:
         with pytest.raises(NotImplementedError) as exc:
             create_store(url)
-        assert "#311" in str(exc.value) or "#312" in str(exc.value)
+        message = str(exc.value)
+        assert "#311" in message
+        assert "#312" in message
 
 
 class TestUnknownScheme:


### PR DESCRIPTION
## Summary

Closes #309. Part of epic #257.

Adds `CQ_DATABASE_URL` as the canonical way to select the cq server's
backing database, with a `create_store(database_url) -> Store` factory
as the single dispatch point for URL → backend selection. SQLite
remains the only working backend; `postgresql+*://...` URLs fail fast
with a `NotImplementedError` pointing at the Phase 2 children
(#311/#312). Backwards-compatible with the existing `CQ_DB_PATH`.

### What changed

- New `cq_server.store.create_store(url)` factory in
  `server/backend/src/cq_server/store/__init__.py`. Dispatches on the
  parsed SQLAlchemy driver:
  - `sqlite:///<path>` → live `SqliteStore` (rejects empty path and
    `:memory:` with a clear `ValueError`).
  - `postgresql://...` and any `postgresql+<driver>://...` →
    `NotImplementedError` naming #311/#312.
  - Anything else → `ValueError` with the offending driver string.
  - Unparseable URLs (`make_url` raising `ArgumentError`) are wrapped
    as `ValueError("Invalid CQ_DATABASE_URL: ...")` and covered by
    `tests/test_store_factory.py::TestMalformedUrl`.
- Lifespan in `app.py` now resolves the URL via
  `resolve_database_url()` once and feeds both `create_store(...)` and
  `run_migrations(...)`, so the migration runner and the runtime store
  cannot diverge on which database they target. The module-level
  `_store` is assigned only after both startup steps succeed, so a
  mid-boot failure can't leak a half-initialised store from the
  previous lifespan.
- `resolve_sqlite_db_path` retired — `create_store` now owns the
  SQLite-vs-Postgres rejection that helper used to do.
- Docs:
  - `DEVELOPMENT.md` documents `CQ_DATABASE_URL` in the self-hosted
    server table and labels `CQ_DB_PATH` as the SQLite shortcut. (The
    env-var table moved out of `README.md` into `DEVELOPMENT.md` in
    the docs refactor #336 on main; this PR's table changes were
    rebased onto that location.)
  - `server/backend/README.md` updates the URL-resolution explainer to
    name `create_store`, link to #311/#312, and points the
    env-variable reference at `DEVELOPMENT.md#self-hosted-server`
    (was `README.md#self-hosted-server` before #336).
  - `docker-compose.yml` adds a commented-out `CQ_DATABASE_URL` example
    showing it wins over `CQ_DB_PATH` when set.

### Acceptance per #309

- ✅ Existing deployments using `CQ_DB_PATH` continue to work
  unchanged (`tests/test_app.py::TestDatabaseUrlBoot::test_boots_with_only_cq_db_path`).
- ✅ `CQ_DATABASE_URL=sqlite:///custom.db` works and wins over
  `CQ_DB_PATH` (`test_boots_with_cq_database_url`,
  `test_cq_database_url_wins_over_cq_db_path`).
- ✅ `postgresql+psycopg://...` (and `postgresql://`,
  `postgresql+psycopg2://`, `postgresql+asyncpg://`) all fail with
  `NotImplementedError` pointing at #311/#312
  (`tests/test_store_factory.py::TestPostgres`).
- ✅ TDD: factory tests for each branch landed before the
  implementation; lifespan smoke tests cover the three env-var combos.
- ✅ Lint clean, full backend test suite green (313 passed).
- ✅ Deployment docs updated to introduce `CQ_DATABASE_URL` and label
  `CQ_DB_PATH` as the SQLite shortcut.

### Notes for reviewers

- Lifespan currently runs `create_store` before `run_migrations` so a
  Postgres URL surfaces the `NotImplementedError` with #311/#312
  guidance rather than failing inside Alembic with a raw psycopg
  `ModuleNotFoundError`. The flip back to migrations-first is gated on
  #310 removing the legacy `_ensure_schema()` path; there's a grep-able
  `TODO(#310)` on the relevant comment.
- The Postgres branch deliberately matches `postgresql` *and* any
  `postgresql+<driver>` suffix rather than a fixed allowlist —
  copy-pasted libpq URLs commonly include `psycopg2` or `asyncpg`, and
  all of them should hit the same self-explanatory error.

## Test plan

- [x] `uv run pytest -q` (server/backend) — 313 passed.
- [x] `uv run pytest tests/test_store_factory.py tests/test_db_url.py tests/test_app.py::TestDatabaseUrlBoot -q`
- [ ] Manual smoke: server boots with no env, with `CQ_DB_PATH` only,
      and with `CQ_DATABASE_URL=sqlite:///...` (covered automatically
      by `TestDatabaseUrlBoot` but worth eyeballing once on a real
      container).
- [ ] Manual smoke: setting `CQ_DATABASE_URL=postgresql+psycopg://...`
      fails fast at startup with the #311/#312 error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
